### PR TITLE
fix(count): grouped querysets now use raw query

### DIFF
--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -18,6 +18,7 @@ const Select = require('./sql/query-select')
 const Update = require('./sql/query-update')
 const Delete = require('./sql/query-delete')
 const Insert = require('./sql/query-insert')
+const Count = require('./sql/query-count')
 
 const daoSym = Symbol('dao')
 
@@ -44,19 +45,33 @@ class QuerySet {
   }
 
   count () {
-    const extra = (
-      this._grouping
-      ? ' OVER ()'
-      : ''
-    )
     const qs = new QuerySet(this[daoSym], this)
     qs._Query = Select
     qs._order = []
-    return qs.annotate({
-      result (ref, push) {
-        return `COUNT(*) ${extra}`
+
+    const getAttrs = Attributes.from(this)
+
+    const annotate = getAttrs.then(attrs => {
+      const isGrouped = Boolean(attrs.grouping)
+
+      if (!isGrouped) {
+        return qs.annotate({
+          result (ref, push) {
+            return `COUNT(*)`
+          }
+        }).valuesList(['result'])
+      } else {
+        qs._Query = Count
+        return qs.raw().then(({db, release, sql, values}) => {
+          return db.query(sql, values).then(({rows}) => {
+            release()
+            return rows.map(({result}) => result) // make it quack the same as the valuesList
+          })
+        })
       }
-    }).valuesList(['result']).then(xs => xs[0])
+    })
+
+    return annotate.then(xs => xs[0])
   }
 
   group (by) {

--- a/lib/sql/query-count.js
+++ b/lib/sql/query-count.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const Select = require('./query-select')
+
+module.exports = class Count extends Select {
+  buildSQL (builder) {
+    return `
+      SELECT COUNT (*) AS "result"
+      FROM (${super.buildSQL(builder)}) t0
+    `.split('\n').map(xs => xs.trim()).join(' ').trim()
+  }
+}

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -530,25 +530,20 @@ test('update allows OR', assert => {
 test('count() on annotated query', assert => {
   const root = NodeObjects.create({name: 'count-annotation'})
   const root2 = NodeObjects.create({name: 'count-annotation'})
-  const refs = Array.from(Array(10)).map((_, idx) => {
+  const root3 = NodeObjects.create({name: 'count-annotation'})
+  const refs = Array.from(Array(20)).map((_, idx) => {
     return RefObjects.create({node: root, val: idx})
   })
 
-  return Promise.all(refs.concat([root2])).then(() => {
+  return Promise.all(refs.concat([root2]).concat([root3])).then(() => {
     const qs = NodeObjects.filter({name: 'count-annotation'}).annotate({
       total (ref) {
         return `sum(${ref('refs.val')})`
       }
     }).group()
 
-    return qs.order('total').then(result => {
-      assert.equal(result.length, 2)
-      assert.equal(result[0][1].total, 45)
-      assert.equal(result[1][1].total, null)
-
-      return qs.count()
-    }).then(result => {
-      assert.equal(Number(result), 2)
+    return qs.order('total').count().then(result => {
+      assert.equal(Number(result), 3)
     })
   })
 })


### PR DESCRIPTION
This enables `.group().count()` without a raw bug

Fixes: https://github.com/chrisdickinson/ormnomnom/issues/32

Relying on: https://github.com/chrisdickinson/ormnomnom/pull/34 and the major bump that comes with