### PR TITLE
feat(support): remove support for node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
 addons:


### PR DESCRIPTION
We're using node 6 as a baseline everywhere now that 8 has hit LTS

We'll need to bump the major after this.