### PR TITLE
dont use column list syntax, fixes postgres 10 support

### DIFF
--- a/lib/sql/query-update.js
+++ b/lib/sql/query-update.js
@@ -39,7 +39,7 @@ module.exports = class Update extends RowCountQuery {
 
     return `
       UPDATE "${dao.tableName}" "${builder.targetTableName}"
-      SET (${keys}) = (${keys.map((key, idx) => '$' + (idx + 1))})
+      SET ${keys.map((key, idx) => key + ' = $' + (idx + 1))}
       ${builder.getUpdateJoinClause()}
       ${builder.getWhereClause(this.values)}
     `.split('\n').map(xs => xs.trim()).join(' ').trim()


### PR DESCRIPTION
postgres 10 doesn't like `SET (col) = (val)` when only updating one column, this switches update queries to always use `SET col = val, col2 = val2` syntax instead which avoids the issue entirely