### PR TITLE
Test refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+.nyc_output

--- a/docs/ref/queryset.md
+++ b/docs/ref/queryset.md
@@ -28,11 +28,11 @@ const onlyTheBest = require('./only-the-best-filter')
 const onlyConsonants = require('./only-consonants')
 
 // get the best consonant letters
-var myLetters = LetterObjects.all()
+let myLetters = LetterObjects.all()
 myLetters = onlyTheBest(onlyConsonants(myLetters))
 
 // get the best letters from the first half of the alphabet
-var firstLetters = LetterObjects.all().slice(0, 13)
+let firstLetters = LetterObjects.all().slice(0, 13)
 firstLetters = onlyTheBest(firstLetters)
 ```
 

--- a/lib/column.js
+++ b/lib/column.js
@@ -7,13 +7,13 @@ const privateAPISym = symbols.privateAPI
 const classToDAOSym = symbols.clsToDAO
 
 class Column {
-  constructor (name, column, validator, opts) {
+  constructor (name, column, validator, opts = {}) {
     opts = Object.assign({}, {
       cls: null,
       isForwardRelation: null,
       remoteColumn: null,
       nullable: null
-    }, opts || {})
+    }, opts)
     this.name = name
     this.column = column
     this.validator = validator
@@ -90,7 +90,7 @@ class ForeignKey extends Column {
     if (this.cls[classToDAOSym]) {
       return this.cls[classToDAOSym][privateAPISym]
     }
-    throw new Error('No DAO registered for ' + this.cls.name)
+    throw new Error(`No DAO registered for ${this.cls.name}`)
   }
 
   remoteColumn () {

--- a/lib/column.js
+++ b/lib/column.js
@@ -31,10 +31,6 @@ class Column {
     throw new Error(`${this.name} is not a join-able column`)
   }
 
-  remoteColumn () {
-    throw new Error(`${this.name} is not a join-able column`)
-  }
-
   dbPrepData (val) {
     return val
   }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -11,7 +11,7 @@ const Mapper = module.exports = class Mapper {
     this.ddl = ddl
     this.submappers = new Map()
     this.tableName = tableName
-    for (var rel in this.ddl) {
+    for (const rel in this.ddl) {
       if (this.ddl[rel].isFK &&
           this.ddl[rel].isForwardRelation) {
         this.submappers.set(
@@ -120,13 +120,13 @@ const Mapper = module.exports = class Mapper {
 Mapper.PREFIX_TO_REGEXP = new Map()
 
 function * keys (obj) {
-  for (var key in obj) {
+  for (const key in obj) {
     yield key
   }
 }
 
 function * values (obj) {
-  for (var key in obj) {
+  for (const key in obj) {
     yield obj[key]
   }
 }

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -112,6 +112,9 @@ class GenericMultipleObjectsReturned extends Error {
 class GenericConflict extends Error {
 }
 
+class GenericMissingUpdateData extends TypeError {
+}
+
 Object.defineProperties(DAO, {
   NotFound: {
     enumerable: false,
@@ -127,6 +130,11 @@ Object.defineProperties(DAO, {
     enumerable: false,
     configurable: false,
     value: GenericConflict
+  },
+  MissingUpdateData: {
+    enumerable: false,
+    configurable: false,
+    value: GenericMissingUpdateData
   }
 })
 
@@ -165,7 +173,7 @@ function addErrors (publicDAO, privateDAO, cls) {
   cls.MissingUpdateData =
   privateDAO.MissingUpdateData =
   publicDAO.MissingUpdateData =
-  class MissingUpdateData extends TypeError {
+  class MissingUpdateData extends GenericMissingUpdateData {
     constructor (msg = `Attempted update of ${privateDAO.modelName} object with no data`) {
       super(msg)
       Error.captureStackTrace(this, MissingUpdateData)

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -88,8 +88,7 @@ proto.update = function (data) {
 }
 
 proto.delete = function (filter) {
-  const qs = this.getQuerySet()
-  return (filter ? qs.filter(filter) : qs).delete()
+  return this.getQuerySet().delete(filter)
 }
 
 proto.getOrCreate = function (data) {

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -162,6 +162,16 @@ function addErrors (publicDAO, privateDAO, cls) {
       this.conflict = conflictType
     }
   }
+  cls.MissingUpdateData =
+  privateDAO.MissingUpdateData =
+  publicDAO.MissingUpdateData =
+  class MissingUpdateData extends TypeError {
+    constructor (msg = `Attempted update of ${privateDAO.modelName} object with no data`) {
+      super(msg)
+      Error.captureStackTrace(this, MissingUpdateData)
+      this.type = type
+    }
+  }
 }
 
 function describeConflict (name, description, type) {

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -171,6 +171,7 @@ function describeConflict (name, description, type) {
 
 symbols.cleanup()
 
+/* istanbul ignore next */
 if (process.env.ORMNOMNOM_LOG_QUERIES) {
   const set = new Set(process.env.ORMNOMNOM_LOG_QUERIES.split(','))
   const check = (

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -50,8 +50,7 @@ DAO.setConnection = function (getConnection) {
   PrivateAPI.setConnection(getConnection)
 }
 
-DAO.fk = function (model, opts) {
-  opts = opts || {}
+DAO.fk = function (model, opts = {}) {
   return {[fkFieldSym]: {model, nullable: opts.nullable}}
 }
 
@@ -136,8 +135,8 @@ function addErrors (publicDAO, privateDAO, cls) {
   cls.NotFound =
   privateDAO.NotFound =
   publicDAO.NotFound = class NotFound extends GenericNotFound {
-    constructor (msg) {
-      super(msg || `${privateDAO.modelName} not found`)
+    constructor (msg = `${privateDAO.modelName} not found`) {
+      super(msg)
       Error.captureStackTrace(this, NotFound)
       this.type = type
     }
@@ -146,8 +145,8 @@ function addErrors (publicDAO, privateDAO, cls) {
   privateDAO.MultipleObjectsReturned =
   publicDAO.MultipleObjectsReturned =
   class MultipleObjectsReturned extends GenericMultipleObjectsReturned {
-    constructor (msg) {
-      super(msg || `Multiple ${privateDAO.modelName} objects returned`)
+    constructor (msg = `Multiple ${privateDAO.modelName} objects returned`) {
+      super(msg)
       Error.captureStackTrace(this, MultipleObjectsReturned)
       this.type = type
     }
@@ -156,8 +155,8 @@ function addErrors (publicDAO, privateDAO, cls) {
   privateDAO.Conflict =
   publicDAO.Conflict =
   class Conflict extends GenericConflict {
-    constructor (msg, conflictType) {
-      super(msg || `Unexpected conflict`)
+    constructor (msg = 'Unexpected conflict', conflictType) {
+      super(msg)
       Error.captureStackTrace(this, Conflict)
       this.type = type
       this.conflict = conflictType

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -163,7 +163,7 @@ function addErrors (publicDAO, privateDAO, cls) {
   privateDAO.Conflict =
   publicDAO.Conflict =
   class Conflict extends GenericConflict {
-    constructor (msg = 'Unexpected conflict', conflictType) {
+    constructor (msg, conflictType) {
       super(msg)
       Error.captureStackTrace(this, Conflict)
       this.type = type

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -92,7 +92,7 @@ proto.delete = function (filter) {
 }
 
 proto.getOrCreate = function (data) {
-  var getObject = this.getQuerySet().get(data)
+  const getObject = this.getQuerySet().get(data)
 
   return getObject.then(obj => {
     return [false, obj]

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -180,9 +180,9 @@ function install (dao) {
 
   const pending = pendingInstallation.get(dao.InstanceCls) || []
   pendingInstallation.delete(dao.InstanceCls)
-  pending.forEach(install => {
+  for (const install of pending) {
     installReverse(install.dao, install.key, dao.publicAPI)
-  })
+  }
 }
 
 function installReverse (src, key, target) {

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -30,14 +30,19 @@ const classToDAOSym = symbols.clsToDAO
 const fkFieldSym = symbols.fkField
 
 class PrivateAPI {
-  constructor (publicAPI, InstanceCls, ddl, options) {
+  constructor (publicAPI, InstanceCls, ddl, options = {}) {
+    options = Object.assign({}, {
+      tableName: defaultName(InstanceCls.name),
+      modelName: InstanceCls.name,
+      primaryKey: 'id'
+    }, options)
+
     this.publicAPI = publicAPI
     this.InstanceCls = InstanceCls
     this.ddl = createDDL(ddl)
-    options = options || {}
-    this.tableName = options.tableName || defaultName(InstanceCls.name)
-    this.modelName = options.modelName || InstanceCls.name
-    this.primaryKeyName = options.primaryKey || 'id'
+    this.tableName = options.tableName
+    this.modelName = options.modelName
+    this.primaryKeyName = options.primaryKey
     this.perBuilderColumns = new WeakMap()
     this.mapper = null
   }
@@ -98,11 +103,11 @@ class PrivateAPI {
         const bits = rhs.split('.')
         let current = lhs
         while (bits.length > 1) {
-          let next = bits.shift()
+          const next = bits.shift()
           current[next] = current[next] || {}
           current = current[next]
         }
-        current[bits[0]] = row[this.tableName + '.' + rhs]
+        current[bits[0]] = row[`${this.tableName}.${rhs}`]
         return lhs
       }, {}))
     }
@@ -111,7 +116,7 @@ class PrivateAPI {
   createValuesListTransformer (values) {
     values = [].concat(values)
     return (row, push) => values.map(xs => {
-      push(row[this.tableName + '.' + xs])
+      push(row[`${this.tableName}.${xs}`])
     })
   }
 
@@ -181,10 +186,10 @@ function install (dao) {
 }
 
 function installReverse (src, key, target) {
-  target[src.tableName + 'SetFor'] = function (data) {
+  target[`${src.tableName}SetFor`] = function (data) {
     data = Promise.cast(data)
     return src.getQuerySet().filter({
-      [key + '.id']: data.get('id')
+      [`${key}.id`]: data.get('id')
     })
   }
 
@@ -200,6 +205,6 @@ function installReverse (src, key, target) {
 
 function defaultName (xs) {
   return xs.replace(/[a-z][A-Z]/g, function (m) {
-    return m[0] + '_' + m[1]
+    return `${m[0]}_${m[1]}`
   }).toLowerCase() + 's'
 }

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -13,7 +13,7 @@ const Column = column.Column
 module.exports = function () {
   module.exports = null
   let conn = null
-  PrivateAPI.setConnection = (c) => {
+  PrivateAPI.setConnection = c => {
     conn = c
   }
   PrivateAPI.getConnection = () => {
@@ -180,7 +180,7 @@ function install (dao) {
 }
 
 function installReverse (src, key, target) {
-  target[`${src.tableName}SetFor`] = (data) => {
+  target[`${src.tableName}SetFor`] = data => {
     data = Promise.cast(data)
     return src.getQuerySet().filter({
       [`${key}.id`]: data.get('id')
@@ -198,7 +198,7 @@ function installReverse (src, key, target) {
 }
 
 function defaultName (xs) {
-  return xs.replace(/[a-z][A-Z]/g, (m) => {
+  return xs.replace(/[a-z][A-Z]/g, m => {
     return `${m[0]}_${m[1]}`
   }).toLowerCase() + 's'
 }

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -71,11 +71,9 @@ class PrivateAPI {
       return this.ddl[name]
     }
 
-    if (builder) {
-      const builderDDL = this.perBuilderColumns.get(builder)
-      if (builderDDL && name in builderDDL) {
-        return builderDDL[name]
-      }
+    const builderDDL = this.perBuilderColumns.get(builder)
+    if (builderDDL && name in builderDDL) {
+      return builderDDL[name]
     }
 
     throw new Error(`"${name}" is not a valid column on ${this.InstanceCls.name}.`)
@@ -94,7 +92,7 @@ class PrivateAPI {
   }
 
   createValuesTransformer (values) {
-    values = Array.isArray(values) ? values : [values]
+    values = [].concat(values)
     return (row, push) => {
       push(values.reduce((lhs, rhs) => {
         var bits = rhs.split('.')
@@ -111,7 +109,7 @@ class PrivateAPI {
   }
 
   createValuesListTransformer (values) {
-    values = Array.isArray(values) ? values : [values]
+    values = [].concat(values)
     return (row, push) => values.map(xs => {
       push(row[this.tableName + '.' + xs])
     })

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -12,7 +12,7 @@ const Column = column.Column
 
 module.exports = function () {
   module.exports = null
-  var conn = null
+  let conn = null
   PrivateAPI.setConnection = function (c) {
     conn = c
   }
@@ -95,10 +95,10 @@ class PrivateAPI {
     values = [].concat(values)
     return (row, push) => {
       push(values.reduce((lhs, rhs) => {
-        var bits = rhs.split('.')
-        var current = lhs
+        const bits = rhs.split('.')
+        let current = lhs
         while (bits.length > 1) {
-          var next = bits.shift()
+          let next = bits.shift()
           current[next] = current[next] || {}
           current = current[next]
         }
@@ -124,7 +124,7 @@ class PrivateAPI {
   }
 
   * columns () {
-    for (var key in this.ddl) {
+    for (const key in this.ddl) {
       if (this.ddl[key].isFK) {
         continue
       }
@@ -134,11 +134,11 @@ class PrivateAPI {
 }
 
 function createDDL (ddl) {
-  var out = {}
-  for (var key in ddl) {
+  const out = {}
+  for (const key in ddl) {
     if (ddl[key][fkFieldSym]) {
-      var info = ddl[key][fkFieldSym]
-      var col = info.column || `${key}_id`
+      const info = ddl[key][fkFieldSym]
+      const col = info.column || `${key}_id`
       out[key] = new ForeignKey(key, info.model, col, null, info.nullable || false, true)
       // TODO: create "final" validator that checks for
       // object-wide consistency for inserts, e.g., "has _either_ X or X_id fk"
@@ -157,12 +157,12 @@ function createDDL (ddl) {
 }
 
 function install (dao) {
-  for (var key in dao.ddl) {
+  for (const key in dao.ddl) {
     if (dao.ddl[key].isFK) {
       if (dao.ddl[key].cls[classToDAOSym]) {
         installReverse(dao, key, dao.ddl[key].cls[classToDAOSym])
       } else {
-        var cls = dao.ddl[key].cls
+        const cls = dao.ddl[key].cls
         pendingInstallation.set(
           cls, (pendingInstallation.get(cls) || []).concat([{
             dao,
@@ -173,7 +173,7 @@ function install (dao) {
     }
   }
 
-  var pending = pendingInstallation.get(dao.InstanceCls) || []
+  const pending = pendingInstallation.get(dao.InstanceCls) || []
   pendingInstallation.delete(dao.InstanceCls)
   pending.forEach(install => {
     installReverse(install.dao, install.key, dao.publicAPI)

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -177,12 +177,6 @@ function install (dao) {
       }
     }
   }
-
-  const pending = pendingInstallation.get(dao.InstanceCls) || []
-  pendingInstallation.delete(dao.InstanceCls)
-  for (const install of pending) {
-    installReverse(install.dao, install.key, dao.publicAPI)
-  }
 }
 
 function installReverse (src, key, target) {

--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -13,10 +13,10 @@ const Column = column.Column
 module.exports = function () {
   module.exports = null
   let conn = null
-  PrivateAPI.setConnection = function (c) {
+  PrivateAPI.setConnection = (c) => {
     conn = c
   }
-  PrivateAPI.getConnection = function () {
+  PrivateAPI.getConnection = () => {
     return conn
   }
   PrivateAPI.errorMap = {}
@@ -186,7 +186,7 @@ function install (dao) {
 }
 
 function installReverse (src, key, target) {
-  target[`${src.tableName}SetFor`] = function (data) {
+  target[`${src.tableName}SetFor`] = (data) => {
     data = Promise.cast(data)
     return src.getQuerySet().filter({
       [`${key}.id`]: data.get('id')
@@ -204,7 +204,7 @@ function installReverse (src, key, target) {
 }
 
 function defaultName (xs) {
-  return xs.replace(/[a-z][A-Z]/g, function (m) {
+  return xs.replace(/[a-z][A-Z]/g, (m) => {
     return `${m[0]}_${m[1]}`
   }).toLowerCase() + 's'
 }

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -55,7 +55,7 @@ class QuerySet {
       if (!isGrouped) {
         return qs.annotate({
           result (ref, push) {
-            return `COUNT(*)`
+            return 'COUNT(*)'
           }
         }).valuesList(['result'])
       } else {
@@ -75,11 +75,7 @@ class QuerySet {
     return annotate.then(xs => xs[0])
   }
 
-  group (by) {
-    if (!by) {
-      by = this[daoSym].primaryKeyName
-    }
-
+  group (by = this[daoSym].primaryKeyName) {
     const qs = new QuerySet(this[daoSym], this)
     qs._grouping = [].concat(by)
     return qs
@@ -101,11 +97,7 @@ class QuerySet {
     return qs
   }
 
-  distinct (expr) {
-    if (arguments.length === 0) {
-      expr = [this[daoSym].primaryKeyName]
-    }
-
+  distinct (expr = [this[daoSym].primaryKeyName]) {
     const qs = new QuerySet(this[daoSym], this)
     qs._distinct = [].concat(expr)
     return qs

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -230,6 +230,7 @@ class QuerySet {
 
     materialize(this).then(stream => {
       const mapper = createMapper(this, stream.annotations)
+      /* istanbul ignore next */
       mapper.on('error', err => outer.emit('error', err))
       stream.on('error', err => {
         // wrap database errors as conflicts where appropriate

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -148,6 +148,9 @@ class QuerySet {
   }
 
   exclude (query) {
+    if (!query) {
+      return this
+    }
     var qs = new QuerySet(this[daoSym], this)
     query[NEGATE_SYM] = true
     qs._filter = query

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -80,13 +80,13 @@ class QuerySet {
       by = this[daoSym].primaryKeyName
     }
 
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._grouping = [].concat(by)
     return qs
   }
 
   aggregate (agg) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._grouping = []
     qs._order = []
     return qs.annotate({
@@ -95,7 +95,7 @@ class QuerySet {
   }
 
   annotate (ann) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._Query = Select
     qs._annotation = ann
     return qs
@@ -106,13 +106,13 @@ class QuerySet {
       expr = [this[daoSym].primaryKeyName]
     }
 
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._distinct = [].concat(expr)
     return qs
   }
 
   order (by) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._order = [].concat(by)
     return qs
   }
@@ -142,7 +142,7 @@ class QuerySet {
   }
 
   filter (query) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._filter = query
     return qs
   }
@@ -151,14 +151,14 @@ class QuerySet {
     if (!query) {
       return this
     }
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     query[NEGATE_SYM] = true
     qs._filter = query
     return qs
   }
 
   slice (start, end) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     switch (arguments.length) {
       case 1:
         qs._slice = [start, Infinity]
@@ -171,7 +171,7 @@ class QuerySet {
   }
 
   delete (query) {
-    var qs = new QuerySet(this[daoSym], (
+    const qs = new QuerySet(this[daoSym], (
       query
       ? this.filter(query)
       : this
@@ -182,7 +182,7 @@ class QuerySet {
   }
 
   update (data) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     qs._Query = Update
     qs._data = data
     qs._transformer = (row, push) => push(row)
@@ -200,7 +200,7 @@ class QuerySet {
         return []
       }
 
-      var qs = new QuerySet(this[daoSym], this)
+      const qs = new QuerySet(this[daoSym], this)
       qs._Query = Insert
       qs._data = data
       return qs.then(xs => {
@@ -212,7 +212,7 @@ class QuerySet {
   }
 
   values (values) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     values = [].concat(values)
     qs._columns = values
     qs._transformer = this[daoSym].createValuesTransformer(values)
@@ -220,7 +220,7 @@ class QuerySet {
   }
 
   valuesList (values) {
-    var qs = new QuerySet(this[daoSym], this)
+    const qs = new QuerySet(this[daoSym], this)
     values = [].concat(values)
     qs._columns = values
     qs._transformer = this[daoSym].createValuesListTransformer(values)
@@ -420,7 +420,7 @@ function materialize (queryset, toStream) {
 
 function rewriteOperationInToSelect (filter) {
   const out = {}
-  for (var key in filter) {
+  for (const key in filter) {
     if (filter[key] && !filter[key][querySetSym]) {
       out[key] = filter[key]
       continue
@@ -445,9 +445,9 @@ function rewriteOperationInToSelect (filter) {
     out[newKey] = filter[key].raw().then(query => {
       query.release()
       return (col, push) => {
-        var len = 0
+        let len = 0
         while (query.values.length) {
-          var next = push(query.values.shift())
+          const next = push(query.values.shift())
           len = len || next
         }
         if (len) {
@@ -465,7 +465,7 @@ function rewriteOperationInToSelect (filter) {
 }
 
 function decorateData (instance, data, dao) {
-  for (var key in data) {
+  for (const key in data) {
     if (data[key] &&
         data[key].constructor &&
         data[key].constructor[classToDAOSym] &&

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -368,7 +368,7 @@ function resolveData (Query, data) {
     )
   }
 
-  return Promise.props(data || {})
+  return Promise.props(data)
 }
 
 function resolveFilter (outer) {

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -82,13 +82,8 @@ class QuerySet {
       by = this[daoSym].primaryKeyName
     }
 
-    by = (
-      Array.isArray(by)
-      ? by
-      : [by]
-    )
     var qs = new QuerySet(this[daoSym], this)
-    qs._grouping = by
+    qs._grouping = [].concat(by)
     return qs
   }
 
@@ -111,19 +106,16 @@ class QuerySet {
   distinct (expr) {
     if (arguments.length === 0) {
       expr = [this[daoSym].primaryKeyName]
-    } else if (!Array.isArray(expr)) {
-      expr = [expr]
     }
 
     var qs = new QuerySet(this[daoSym], this)
-    qs._distinct = expr
+    qs._distinct = [].concat(expr)
     return qs
   }
 
   order (by) {
-    by = Array.isArray(by) ? by : [by]
     var qs = new QuerySet(this[daoSym], this)
-    qs._order = by
+    qs._order = [].concat(by)
     return qs
   }
 
@@ -187,6 +179,7 @@ class QuerySet {
     qs._transformer = (row, push) => push(row)
     return qs.then(xs => xs[0])
   }
+
   update (data) {
     var qs = new QuerySet(this[daoSym], this)
     qs._Query = Update
@@ -219,7 +212,7 @@ class QuerySet {
 
   values (values) {
     var qs = new QuerySet(this[daoSym], this)
-    values = Array.isArray(values) ? values : [values]
+    values = [].concat(values)
     qs._columns = values
     qs._transformer = this[daoSym].createValuesTransformer(values)
     return qs
@@ -227,7 +220,7 @@ class QuerySet {
 
   valuesList (values) {
     var qs = new QuerySet(this[daoSym], this)
-    values = Array.isArray(values) ? values : [values]
+    values = [].concat(values)
     qs._columns = values
     qs._transformer = this[daoSym].createValuesListTransformer(values)
     return qs

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -184,8 +184,8 @@ class QuerySet {
   create (data) {
     const isBulk = Array.isArray(data)
     const getData = isBulk
-        ? Promise.all(data.map(Promise.props))
-        : Promise.props(data).then(xs => [xs])
+        ? Promise.all(data.map(xs => Promise.props(xs || {})))
+        : Promise.props(data || {}).then(xs => [xs])
 
     return getData.then(data => {
       if (isBulk && !data.length) {

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -110,7 +110,7 @@ class QuerySet {
   }
 
   get (query) {
-    return this.filter(query).slice(0, 2).then((xs) => {
+    return this.filter(query).slice(0, 2).then(xs => {
       switch (xs.length) {
         case 0:
           throw new this[daoSym].NotFound()
@@ -376,9 +376,7 @@ function resolveFilter (outer) {
   return Promise.all(outer).map(filter => {
     return (
       Array.isArray(filter)
-      ? Promise.all(filter.map(ys => {
-        return Promise.props(rewriteOperationInToSelect(ys || {}))
-      }))
+      ? Promise.all(filter.map(ys => Promise.props(rewriteOperationInToSelect(ys || {}))))
       : Promise.props(rewriteOperationInToSelect(filter))
     ).then(result => {
       result[NEGATE_SYM] = filter[NEGATE_SYM]

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -39,9 +39,7 @@ class QuerySet {
 
     this._parent = parent
     this[daoSym] = dao
-  }
-
-  [querySetSym] () {
+    this[querySetSym] = true
   }
 
   count () {

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -462,10 +462,6 @@ function rewriteOperationInToSelect (filter) {
 }
 
 function decorateData (instance, data, dao) {
-  if (!instance) {
-    return
-  }
-
   for (var key in data) {
     if (data[key] &&
         data[key].constructor &&

--- a/lib/sql/builder.js
+++ b/lib/sql/builder.js
@@ -113,7 +113,7 @@ module.exports = class Builder {
       this.tableNameMap.set(name, 1)
       return name
     }
-    var val = this.tableNameMap.get(name)
+    const val = this.tableNameMap.get(name)
     this.tableNameMap.set(name, val + 1)
     return `${name}_${val}`
   }
@@ -133,7 +133,7 @@ module.exports = class Builder {
       parent = parent.add(new where.Not())
     }
 
-    for (var i = 0; i < keys.length; ++i) {
+    for (let i = 0; i < keys.length; ++i) {
       const key = keys[i]
       const bits = key.split(':')
       parent.add(new where.Comparison(
@@ -150,7 +150,7 @@ module.exports = class Builder {
       ? this.where.add(new where.Not()).add(new where.Or())
       : this.where.add(new where.Or())
 
-    for (var i = 0; i < clause.length; ++i) {
+    for (let i = 0; i < clause.length; ++i) {
       const subclause = root.add(new where.And())
       this.addWhereAll(clause[i], subclause)
     }
@@ -198,7 +198,7 @@ module.exports = class Builder {
   }
 
   addOrderClause (col) {
-    var dir = 'ASC'
+    let dir = 'ASC'
     col = col.replace(/^-/, () => {
       dir = 'DESC'
       return ''

--- a/lib/sql/builder.js
+++ b/lib/sql/builder.js
@@ -119,15 +119,20 @@ module.exports = class Builder {
   }
 
   addWhereAll (clause, parent) {
+    parent = parent || this.where
+
     const keys = Object.keys(clause)
     if (!keys.length) {
+      parent = clause[this.negateSym]
+        ? parent.add(new where.Not()).add(new where.And())
+        : parent.add(new where.And())
       return
     }
 
-    parent = parent || this.where
     if (clause[this.negateSym]) {
       parent = parent.add(new where.Not())
     }
+
     for (var i = 0; i < keys.length; ++i) {
       const key = keys[i]
       const bits = key.split(':')
@@ -141,10 +146,6 @@ module.exports = class Builder {
   }
 
   addWhereAny (clause) {
-    if (!clause.length) {
-      return
-    }
-
     const root = clause[this.negateSym]
       ? this.where.add(new where.Not()).add(new where.Or())
       : this.where.add(new where.Or())

--- a/lib/sql/builder.js
+++ b/lib/sql/builder.js
@@ -102,6 +102,7 @@ module.exports = class Builder {
   }
 
   addTarget (col) {
+    /* istanbul ignore next */
     if (this.selecting.has(col)) {
       return
     }
@@ -209,9 +210,9 @@ module.exports = class Builder {
   }
 
   addDistinctExpression (set) {
-    Array.from(set).map(col => {
+    for (const col of set.values()) {
       this.distinctExpressions.push(this.referenceColumn(col))
-    })
+    }
   }
 
   referenceColumn (name, shouldContributeColumns, shouldUnrefFK) {

--- a/lib/sql/builder.js
+++ b/lib/sql/builder.js
@@ -118,9 +118,7 @@ module.exports = class Builder {
     return `${name}_${val}`
   }
 
-  addWhereAll (clause, parent) {
-    parent = parent || this.where
-
+  addWhereAll (clause, parent = this.where) {
     const keys = Object.keys(clause)
     if (!keys.length) {
       parent = clause[this.negateSym]
@@ -254,7 +252,7 @@ module.exports = class Builder {
     if (this.where.children.length === 0) {
       return ''
     }
-    return 'WHERE ' + this.where.toSQL(values)
+    return `WHERE ${this.where.toSQL(values)}`
   }
 
   getOrderClause () {

--- a/lib/sql/builder.js
+++ b/lib/sql/builder.js
@@ -145,11 +145,10 @@ module.exports = class Builder {
       return
     }
 
-    const root = this.where.add(
-      clause[this.negateSym]
-      ? new where.Not().add(new where.Or())
-      : new where.Or()
-    )
+    const root = clause[this.negateSym]
+      ? this.where.add(new where.Not()).add(new where.Or())
+      : this.where.add(new where.Or())
+
     for (var i = 0; i < clause.length; ++i) {
       const subclause = root.add(new where.And())
       this.addWhereAll(clause[i], subclause)

--- a/lib/sql/builder.js
+++ b/lib/sql/builder.js
@@ -268,9 +268,6 @@ module.exports = class Builder {
   }
 
   getBoundsClause () {
-    if (!this.bounds.length) {
-      return ''
-    }
     return (
       isFinite(this.bounds[1])
       ? `LIMIT ${this.bounds[1]} `

--- a/lib/sql/query-delete.js
+++ b/lib/sql/query-delete.js
@@ -4,11 +4,11 @@ const RowCountQuery = require('./query').RowCountQuery
 
 module.exports = class Delete extends RowCountQuery {
   buildSQL (builder) {
-    this.attrs.filter.forEach(clause => {
+    for (const clause of this.attrs.filter) {
       Array.isArray(clause)
         ? builder.addWhereAny(clause)
         : builder.addWhereAll(clause)
-    })
+    }
 
     return `
       DELETE FROM "${this.attrs.dao.tableName}" "${builder.targetTableName}"

--- a/lib/sql/query-insert.js
+++ b/lib/sql/query-insert.js
@@ -10,7 +10,7 @@ module.exports = class Insert extends RowStreamQuery {
     const data = this.attrs.data
     const validator = {}
     const returningKeys = []
-    for (var key in dao.ddl) {
+    for (const key in dao.ddl) {
       const col = dao.ddl[key]
       if (col.isFK && !col.isForwardRelation) {
         continue
@@ -27,10 +27,10 @@ module.exports = class Insert extends RowStreamQuery {
     const insertSchema = new Set()
     const preppedData = new Array(data.length)
     const allowUnknown = {allowUnknown: true}
-    for (var i = 0; i < data.length; ++i) {
+    for (let i = 0; i < data.length; ++i) {
       const keys = Object.keys(data[i])
       preppedData[i] = {}
-      for (var j = 0; j < keys.length; ++j) {
+      for (let j = 0; j < keys.length; ++j) {
         if (!dao.ddl[keys[j]]) {
           continue
         }
@@ -42,15 +42,15 @@ module.exports = class Insert extends RowStreamQuery {
         throw validated.error
       }
       preppedData[i] = validated.value
-      for (var resultKey in validated.value) {
+      for (const resultKey in validated.value) {
         insertSchema.add(resultKey)
       }
     }
 
     const rows = []
-    for (var x = 0; x < preppedData.length; ++x) {
+    for (let x = 0; x < preppedData.length; ++x) {
       const row = []
-      for (var col of insertSchema) {
+      for (const col of insertSchema) {
         row.push('$' + this.values.push(preppedData[x][col]))
       }
       rows.push(`(${row.join(', ')})`)

--- a/lib/sql/query-insert.js
+++ b/lib/sql/query-insert.js
@@ -56,9 +56,7 @@ module.exports = class Insert extends RowStreamQuery {
       rows.push(`(${row.join(', ')})`)
     }
 
-    const columns = Array.from(insertSchema).map(xs => {
-      return `"${dao.ddl[xs].column}"`
-    })
+    const columns = Array.from(insertSchema).map(xs => `"${dao.ddl[xs].column}"`)
 
     const values = insertSchema.size ? `(${columns}) VALUES ${rows}` : 'DEFAULT VALUES'
 

--- a/lib/sql/query-insert.js
+++ b/lib/sql/query-insert.js
@@ -54,13 +54,11 @@ module.exports = class Insert extends RowStreamQuery {
     for (var x = 0; x < preppedData.length; ++x) {
       const row = []
       for (var col of insertSchema) {
-        if (col in preppedData[x]) {
-          row.push(
-            col in preppedData[x]
-              ? '$' + this.values.push(preppedData[x][col])
-              : 'DEFAULT'
-          )
-        }
+        row.push(
+          col in preppedData[x]
+            ? '$' + this.values.push(preppedData[x][col])
+            : 'DEFAULT'
+        )
       }
       rows.push(`(${row.join(', ')})`)
     }

--- a/lib/sql/query-insert.js
+++ b/lib/sql/query-insert.js
@@ -60,9 +60,11 @@ module.exports = class Insert extends RowStreamQuery {
       return `"${dao.ddl[xs].column}"`
     })
 
+    const values = insertSchema.size ? `(${columns}) VALUES ${rows}` : 'DEFAULT VALUES'
+
     return `
       INSERT INTO "${dao.tableName}"
-      (${columns}) VALUES ${rows}
+      ${values}
       RETURNING ${returningKeys.map(
         xs => '"' + xs + '" AS "' + dao.tableName + '.' + xs + '"'
       )}

--- a/lib/sql/query-insert.js
+++ b/lib/sql/query-insert.js
@@ -43,9 +43,6 @@ module.exports = class Insert extends RowStreamQuery {
       }
       preppedData[i] = validated.value
       for (var resultKey in validated.value) {
-        if (!dao.ddl[resultKey] || !(resultKey in validator)) {
-          continue
-        }
         insertSchema.add(resultKey)
       }
     }
@@ -54,11 +51,7 @@ module.exports = class Insert extends RowStreamQuery {
     for (var x = 0; x < preppedData.length; ++x) {
       const row = []
       for (var col of insertSchema) {
-        row.push(
-          col in preppedData[x]
-            ? '$' + this.values.push(preppedData[x][col])
-            : 'DEFAULT'
-        )
+        row.push('$' + this.values.push(preppedData[x][col]))
       }
       rows.push(`(${row.join(', ')})`)
     }

--- a/lib/sql/query-select.js
+++ b/lib/sql/query-select.js
@@ -25,14 +25,17 @@ module.exports = class Select extends RowStreamQuery {
     builder.addBoundsFromSlice(this.attrs.slice)
 
     if (this.attrs.order && this.attrs.order.length) {
-      this.attrs.order.forEach(xs => builder.addOrderClause(xs))
+      for (const clause of this.attrs.order) {
+        builder.addOrderClause(clause)
+      }
     }
 
-    this.attrs.filter.forEach(clause => {
+    for (const clause of this.attrs.filter) {
       Array.isArray(clause)
         ? builder.addWhereAny(clause)
         : builder.addWhereAll(clause)
-    })
+    }
+
     return `
       SELECT
       ${builder.getSelectColumnsClause()}

--- a/lib/sql/query-update.js
+++ b/lib/sql/query-update.js
@@ -11,22 +11,22 @@ module.exports = class Update extends RowCountQuery {
     const validator = {}
     const dao = this.attrs.dao
     const data = this.attrs.data
-    for (var key in data) {
+    for (const key in data) {
       if (!dao.ddl[key]) {
         continue
       }
       if (dao.ddl[key].isFK && !dao.ddl[key].isForwardRelation) {
         continue
       }
-      var col = dao.ddl[key]
-      var val = col.dbPrepData(data[key])
+      const col = dao.ddl[key]
+      const val = col.dbPrepData(data[key])
       preppedData[key] = val
       validator[key] = col.getDataValidator()
       keys.push(`"${col.column}"`)
       this.values.push(val)
     }
 
-    var result = joi.validate(preppedData, validator)
+    const result = joi.validate(preppedData, validator)
     if (result.error) {
       throw result.error
     }

--- a/lib/sql/query-update.js
+++ b/lib/sql/query-update.js
@@ -31,11 +31,11 @@ module.exports = class Update extends RowCountQuery {
       throw result.error
     }
 
-    this.attrs.filter.forEach(clause => {
+    for (const clause of this.attrs.filter) {
       Array.isArray(clause)
         ? builder.addWhereAny(clause)
         : builder.addWhereAll(clause)
-    })
+    }
 
     return `
       UPDATE "${dao.tableName}" "${builder.targetTableName}"

--- a/lib/sql/query-update.js
+++ b/lib/sql/query-update.js
@@ -26,6 +26,10 @@ module.exports = class Update extends RowCountQuery {
       this.values.push(val)
     }
 
+    if (!keys.length) {
+      throw new dao.MissingUpdateData()
+    }
+
     const result = joi.validate(preppedData, validator)
     if (result.error) {
       throw result.error

--- a/lib/sql/query.js
+++ b/lib/sql/query.js
@@ -23,6 +23,7 @@ class Query {
     )(pair.connection, this.values, this.sql, pair.release, this.annotations)
   }
 
+  /* istanbul ignore next */
   [TO_STREAM] () {
     throw new Error('Query#TO_STREAM: not implemented')
   }

--- a/lib/sql/query.js
+++ b/lib/sql/query.js
@@ -35,7 +35,7 @@ class RowCountQuery extends Query {
       objectMode: true,
       read (n) {}
     })
-    db.query(sql, values, function (err, rows) {
+    db.query(sql, values, (err, rows) => {
       if (err) {
         return stream.emit('error', err)
       }

--- a/lib/sql/where.js
+++ b/lib/sql/where.js
@@ -49,9 +49,9 @@ class Not extends Operand {
 }
 
 class Comparison {
-  constructor (column, operand, value, fullkey) {
+  constructor (column, operand = 'eq', value, fullkey) {
     this.column = column
-    this.operand = operand || 'eq'
+    this.operand = operand
     this.value = value
     this.fullkey = fullkey
   }

--- a/lib/sql/where.js
+++ b/lib/sql/where.js
@@ -16,9 +16,6 @@ class Operand {
 
 class And extends Operand {
   toSQL (values) {
-    if (this.children.length === 0) {
-      return '1'
-    }
     return (
       this.children.length < 2
       ? this.children[0].toSQL(values)
@@ -29,9 +26,6 @@ class And extends Operand {
 
 class Or extends Operand {
   toSQL (values) {
-    if (this.children.length === 0) {
-      return '1'
-    }
     return (
       this.children.length < 2
       ? this.children[0].toSQL(values)

--- a/lib/sql/where.js
+++ b/lib/sql/where.js
@@ -16,6 +16,10 @@ class Operand {
 
 class And extends Operand {
   toSQL (values) {
+    if (this.children.length === 0) {
+      return '1=1'
+    }
+
     return (
       this.children.length < 2
       ? this.children[0].toSQL(values)
@@ -26,6 +30,10 @@ class And extends Operand {
 
 class Or extends Operand {
   toSQL (values) {
+    if (this.children.length === 0) {
+      return '1=1'
+    }
+
     return (
       this.children.length < 2
       ? this.children[0].toSQL(values)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,11 +1620,6 @@
         }
       }
     },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -1875,11 +1870,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1892,20 +1882,42 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
-    },
     "joi": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.0.tgz",
+      "integrity": "sha512-x6pGmDYI6hwNi3skP6irQqRaJntzeaWmZ4rsnjc/NTlf6P5Gp3Aw/O8REe8oLJ6wPhrzd9K3RW1m3Yz/Hx4Weg==",
       "requires": {
-        "hoek": "4.2.0",
-        "isemail": "2.2.1",
-        "items": "2.1.1",
-        "topo": "2.0.2"
+        "hoek": "5.0.2",
+        "isemail": "3.0.0",
+        "topo": "3.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+          "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
+        },
+        "isemail": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
+          "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        },
+        "topo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+          "requires": {
+            "hoek": "5.0.2"
+          }
+        }
       }
     },
     "js-string-escape": {
@@ -5552,14 +5564,6 @@
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
       "integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ==",
       "dev": true
-    },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
     },
     "tough-cookie": {
       "version": "2.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -855,6 +855,27 @@
         "is-obj": "1.0.1"
       }
     },
+    "dotgitignore": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
+      "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -1392,12 +1413,6 @@
       "requires": {
         "is-property": "1.0.2"
       }
-    },
-    "generic-pool": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
-      "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8=",
-      "dev": true
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -4101,17 +4116,17 @@
       }
     },
     "pg": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
-      "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
+      "integrity": "sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
       "dev": true,
       "requires": {
         "buffer-writer": "1.0.1",
         "js-string-escape": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "1.8.0",
-        "pg-types": "1.13.0",
+        "pg-pool": "2.0.3",
+        "pg-types": "1.12.1",
         "pgpass": "1.0.2",
         "semver": "4.3.2"
       }
@@ -4134,14 +4149,10 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
-      "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
-      "dev": true,
-      "requires": {
-        "generic-pool": "2.4.3",
-        "object-assign": "4.1.0"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.3.tgz",
+      "integrity": "sha1-wCIDLIlJ8xKk+R+2QJzgQHa+Mlc=",
+      "dev": true
     },
     "pg-query-stream": {
       "version": "1.1.1",
@@ -4152,12 +4163,11 @@
       }
     },
     "pg-types": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
-      "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
       "dev": true,
       "requires": {
-        "pg-int8": "1.0.1",
         "postgres-array": "1.0.2",
         "postgres-bytea": "1.0.0",
         "postgres-date": "1.0.3",
@@ -5286,14 +5296,15 @@
       }
     },
     "standard-version": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.2.0.tgz",
-      "integrity": "sha1-MBfoxc7SqS23UBeQJVw7qFFXN10=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.3.0.tgz",
+      "integrity": "sha512-2UJ2BIUNa7+41PH4FvYicSQED2LCt2RXjmNFis+JZlxZtwzNnGn4uuL8WBUqHoC9b+bJ0AHIAX/bilzm+pGPeA==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "conventional-changelog": "1.1.7",
         "conventional-recommended-bump": "1.1.0",
+        "dotgitignore": "1.0.3",
         "figures": "1.7.0",
         "fs-access": "1.0.1",
         "semver": "5.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,341 +5,377 @@
   "requires": true,
   "dependencies": {
     "@iterables/chain": {
-      "version": "https://registry.npmjs.org/@iterables/chain/-/chain-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@iterables/chain/-/chain-1.0.1.tgz",
       "integrity": "sha1-m2U4a9E6fPdD4qzJKzVA25Kzp7g="
     },
     "@iterables/map": {
-      "version": "https://registry.npmjs.org/@iterables/map/-/map-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@iterables/map/-/map-1.0.1.tgz",
       "integrity": "sha1-GDsRv8KISmDwn3wu06kTXTIvi/E="
     },
     "@iterables/reduce": {
-      "version": "https://registry.npmjs.org/@iterables/reduce/-/reduce-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@iterables/reduce/-/reduce-1.0.1.tgz",
       "integrity": "sha1-bK9VbNMDwheulHf8SBYMVXmjVCM="
     },
     "@iterables/zip": {
-      "version": "https://registry.npmjs.org/@iterables/zip/-/zip-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@iterables/zip/-/zip-1.0.2.tgz",
       "integrity": "sha1-qCrAmbWiWfW78xQp8SNmZoogGcc="
     },
     "JSONStream": {
-      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-        "through": "http://localhost:52225/through/-/through-2.3.8.tgz"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "acorn": {
-      "version": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
     "ajv": {
-      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz",
-      "integrity": "sha1-lH6TBJeQlCsqLWCoKJsokk05+Yc=",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
-      "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
-      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "ap": {
-      "version": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
-      "integrity": "sha1-rglCYAspkS8NKxTsYMRejzMLYRA=",
-      "dev": true
-    },
     "argparse": {
-      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-find-index": {
-      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-ify": {
-      "version": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
     "array-union": {
-      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
-      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array.prototype.find": {
-      "version": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-          "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-            "function-bind": "http://localhost:52225/function-bind/-/function-bind-1.1.0.tgz",
-            "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-            "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
-          }
-        }
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "arrify": {
-      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
-      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babel-code-frame": {
-      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        "tweetnacl": "0.14.5"
       }
     },
     "bind-obj-methods": {
-      "version": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
       "integrity": "sha1-T1l5ysFXk633DkiBYeRj4gnKUJw=",
       "dev": true
     },
     "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-      "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-        "concat-map": "http://localhost:52225/concat-map/-/concat-map-0.0.1.tgz"
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "buffer-shims": {
-      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
     "buffer-writer": {
-      "version": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
       "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
       "dev": true
     },
     "builtin-modules": {
-      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "caller-path": {
-      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
-      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
-      "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
     "camelcase-keys": {
-      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
     "center-align": {
-      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "circular-json": {
-      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clean-yaml-object": {
-      "version": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
       "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
       "dev": true
     },
     "cli-cursor": {
-      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
-      "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
       },
       "dependencies": {
         "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
@@ -347,2740 +383,2415 @@
       }
     },
     "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
-      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "color-support": {
-      "version": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz",
-      "integrity": "sha1-ScyZuJ0b3vEpLp2TI8ZpcaM+uJ0=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
     "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-      }
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "dev": true
     },
     "compare-func": {
-      "version": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-        "dot-prop": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
       }
     },
     "concat-map": {
-      "version": "http://localhost:52225/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-        "typedarray": "http://localhost:52225/typedarray/-/typedarray-0.0.6.tgz"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-          }
-        }
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
       }
     },
     "contains-path": {
-      "version": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "conventional-changelog": {
-      "version": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.3.tgz",
-      "integrity": "sha1-JigweKw4wJTfKvFgSwpGu8AWXE0=",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
+      "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.3.tgz",
-        "conventional-changelog-atom": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-        "conventional-changelog-codemirror": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-        "conventional-changelog-core": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.8.0.tgz",
-        "conventional-changelog-ember": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.5.tgz",
-        "conventional-changelog-eslint": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-        "conventional-changelog-express": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-        "conventional-changelog-jquery": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-        "conventional-changelog-jscs": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-        "conventional-changelog-jshint": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz"
+        "conventional-changelog-angular": "1.6.0",
+        "conventional-changelog-atom": "0.1.2",
+        "conventional-changelog-codemirror": "0.2.1",
+        "conventional-changelog-core": "1.9.5",
+        "conventional-changelog-ember": "0.2.10",
+        "conventional-changelog-eslint": "0.2.1",
+        "conventional-changelog-express": "0.2.1",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.2.1"
       }
     },
     "conventional-changelog-angular": {
-      "version": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.3.tgz",
-      "integrity": "sha1-586AeoXdR1DhtBf3ZgRUl1EeByY=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.0.tgz",
+      "integrity": "sha1-CiagcfLJ/PzyuGugz79uYwG3W/o=",
       "dev": true,
       "requires": {
-        "compare-func": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-        "github-url-from-git": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-atom": {
-      "version": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-      "integrity": "sha1-Z6R8ZqQrL4kJ7xWHyZia4d5zC5I=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
+      "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-codemirror": {
-      "version": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-      "integrity": "sha1-dXelkdv5tTjnoVCn7mL2WihyszQ=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
+      "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.8.0.tgz",
-      "integrity": "sha1-l3hItBbK8V+wnyCxKmLUDvFFuVc=",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.5.tgz",
+      "integrity": "sha1-XbdWba18DLddr0f7spdve/mSjB0=",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-        "conventional-commits-parser": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-        "get-pkg-repo": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-        "git-raw-commits": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-        "git-remote-origin-url": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-        "git-semver-tags": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "through2": "http://localhost:52225/through2/-/through2-2.0.1.tgz"
+        "conventional-changelog-writer": "2.0.3",
+        "conventional-commits-parser": "2.1.0",
+        "dateformat": "1.0.12",
+        "get-pkg-repo": "1.4.0",
+        "git-raw-commits": "1.3.0",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.2.3",
+        "lodash": "4.17.4",
+        "normalize-package-data": "2.4.0",
+        "q": "1.5.1",
+        "read-pkg": "1.1.0",
+        "read-pkg-up": "1.0.1",
+        "through2": "2.0.3"
       }
     },
     "conventional-changelog-ember": {
-      "version": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.5.tgz",
-      "integrity": "sha1-ziHVz4PNXr4F0j/fIy2IRPS1ak8=",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.10.tgz",
+      "integrity": "sha512-LBBBZO6Q7ib4HhSdyCNVR25OtaXl710UJg1aSHCLmR8AjuXKs3BO8tnbY1MH+D1C+z5IFoEDkpjOddefNTyhCQ==",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-eslint": {
-      "version": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-      "integrity": "sha1-pSQR6ZngUBzlALhWsKZD0DMJB+I=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
+      "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-express": {
-      "version": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-      "integrity": "sha1-VcbIQcgRliA2wDe9vZZKVK4xD84=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
+      "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jquery": {
-      "version": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jscs": {
-      "version": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jshint": {
-      "version": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
-      "integrity": "sha1-AMq46aMxdIer2UxNhGcTQpGNKgc=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
+      "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
       "dev": true,
       "requires": {
-        "compare-func": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-writer": {
-      "version": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-      "integrity": "sha1-P0y00APrtWmJ0w00WJO1KkNjnI4=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz",
+      "integrity": "sha512-2E1h7UXL0fhRO5h0CxDZ5EBc5sfBZEQePvuZ+gPvApiRrICUyNDy/NQIP+2TBd4wKZQf2Zm7TxbzXHG5HkPIbA==",
       "dev": true,
       "requires": {
-        "compare-func": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-        "conventional-commits-filter": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "split": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-        "through2": "http://localhost:52225/through2/-/through2-2.0.1.tgz"
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.1.1",
+        "dateformat": "1.0.12",
+        "handlebars": "4.0.11",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.4",
+        "meow": "3.7.0",
+        "semver": "5.4.1",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "conventional-commits-filter": {
-      "version": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-      "integrity": "sha1-b8KmWTcrw/IznPn//34bA0S5MDk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz",
+      "integrity": "sha512-bQyatySNKHhcaeKVr9vFxYWA1W1Tdz6ybVMYDmv4/FhOXY1+fchiW07TzRbIQZhVa4cvBwrEaEUQBbCncFSdJQ==",
       "dev": true,
       "requires": {
-        "is-subset": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-        "modify-values": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.0"
       }
     },
     "conventional-commits-parser": {
-      "version": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-      "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz",
+      "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-        "is-text-path": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "split2": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-        "through2": "http://localhost:52225/through2/-/through2-2.0.1.tgz",
-        "trim-off-newlines": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz"
+        "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
+        "lodash": "4.17.4",
+        "meow": "3.7.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3",
+        "trim-off-newlines": "1.0.1"
       }
     },
     "conventional-recommended-bump": {
-      "version": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-0.3.0.tgz",
-      "integrity": "sha1-6Dnej1fLtDRFyLSWdAHeBkTEJdg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.1.0.tgz",
+      "integrity": "sha512-WK0HnYnXd9e8J1YezUlfle+Pz7HB1RYvIH6gPLAXoroQTzDSfNfGM1tHHmdrJw0/4BMr+zw0U9V1WzFEfQwE3w==",
       "dev": true,
       "requires": {
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-        "conventional-commits-filter": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-        "conventional-commits-parser": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-        "git-latest-semver-tag": "https://registry.npmjs.org/git-latest-semver-tag/-/git-latest-semver-tag-1.0.2.tgz",
-        "git-raw-commits": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        "concat-stream": "1.6.0",
+        "conventional-commits-filter": "1.1.1",
+        "conventional-commits-parser": "2.1.0",
+        "git-raw-commits": "1.3.0",
+        "git-semver-tags": "1.2.3",
+        "meow": "3.7.0",
+        "object-assign": "4.1.0"
       }
     },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
-      "integrity": "sha1-35M4dujG9HjvsE9NOrcNyWt+Wo4=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
       "requires": {
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-        "lcov-parse": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-        "log-driver": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
         "js-yaml": {
-          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
           "dev": true,
           "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
           }
         },
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "cross-spawn": {
-      "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        "boom": "2.10.1"
       }
     },
     "currently-unhandled": {
-      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
-      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+        "es5-ext": "0.10.37"
       }
     },
     "dargs": {
-      "version": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        "number-is-nan": "1.0.1"
       }
     },
     "dashdash": {
-      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "dateformat": {
-      "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
       },
       "dependencies": {
         "get-stdin": {
-          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
         }
       }
     },
     "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-      "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
-        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        "ms": "2.0.0"
       }
     },
     "debug-log": {
-      "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
     "decamelize": {
-      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "deep-is": {
-      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "deeper": {
-      "version": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
-      "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g=",
-      "dev": true
-    },
     "define-properties": {
-      "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "http://localhost:52225/foreach/-/foreach-2.0.5.tgz",
-        "object-keys": "https://registry.internal.npmjs.com/o/object-keys/_attachments/object-keys-1.0.11.tgz"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "deglob": {
-      "version": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
       "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
       "dev": true,
       "requires": {
-        "find-root": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-        "pkg-config": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-        "run-parallel": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-        "uniq": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+        "find-root": "1.1.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.6",
+        "uniq": "1.0.1"
       }
     },
     "del": {
-      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
     "doctrine": {
-      "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
       "dev": true,
       "requires": {
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz"
+        "esutils": "2.0.2"
       }
     },
     "dot-prop": {
-      "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+        "is-obj": "1.0.1"
       }
     },
     "ecc-jsbn": {
-      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+        "jsbn": "0.1.1"
       }
     },
     "error-ex": {
-      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
-      "version": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
-      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
-      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+        "d": "1.0.0",
+        "es5-ext": "0.10.37",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
-      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-        "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-      },
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-          "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-          "dev": true,
-          "requires": {
-            "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-          }
-        },
-        "es6-iterator": {
-          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true,
-          "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-          }
-        },
-        "es6-symbol": {
-          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true,
-          "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        }
+        "d": "1.0.0",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-set": {
-      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-      },
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-          "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-          "dev": true,
-          "requires": {
-            "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-          }
-        },
-        "es6-iterator": {
-          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true,
-          "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-          }
-        },
-        "es6-symbol": {
-          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true,
-          "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        }
+        "d": "1.0.0",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
-      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+        "d": "1.0.0",
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
-      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-      },
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-          "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-          "dev": true,
-          "requires": {
-            "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-          }
-        },
-        "es6-iterator": {
-          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true,
-          "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-          }
-        },
-        "es6-symbol": {
-          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true,
-          "requires": {
-            "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        }
+        "d": "1.0.0",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
-      "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "eslint": {
-      "version": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-        "espree": "https://registry.npmjs.org/espree/-/espree-3.4.1.tgz",
-        "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "2.0.2",
+        "escope": "3.6.0",
+        "espree": "3.5.2",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.1",
+        "is-resolvable": "1.0.1",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       }
     },
     "eslint-config-standard": {
-      "version": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.0.tgz",
-      "integrity": "sha1-nlpJXDKq6KqK61gLcD72RaF2Xps=",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
+      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.1.tgz",
-      "integrity": "sha1-zU5GPQJo4tnnB/YfQvc/WzMzxkI=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        "debug": "2.6.9",
+        "object-assign": "4.1.0",
+        "resolve": "1.5.0"
       }
     },
     "eslint-module-utils": {
-      "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
-      "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
-        },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       }
     },
     "eslint-plugin-import": {
-      "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
       "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-        "contains-path": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-        "eslint-import-resolver-node": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-        "eslint-module-utils": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
-        "has": "http://localhost:52225/has/-/has-1.0.1.tgz",
-        "lodash.cond": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "pkg-up": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.2.3",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "pkg-up": "1.0.0"
       },
       "dependencies": {
         "doctrine": {
-          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         }
       }
     },
     "eslint-plugin-node": {
-      "version": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz",
-      "integrity": "sha1-gpWcqa7Xn8vSi7GxiNBcrAT7M2M=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
+      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
-        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "object-assign": "4.1.0",
+        "resolve": "1.5.0",
+        "semver": "5.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
     },
     "eslint-plugin-promise": {
-      "version": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
       "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-        "has": "http://localhost:52225/has/-/has-1.0.1.tgz",
-        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz",
-        "object.assign": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz"
+        "array.prototype.find": "2.0.4",
+        "doctrine": "1.5.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "1.4.1",
+        "object.assign": "4.1.0"
       },
       "dependencies": {
         "doctrine": {
-          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         }
       }
     },
     "eslint-plugin-standard": {
-      "version": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
       "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
       "dev": true
     },
     "espree": {
-      "version": "https://registry.npmjs.org/espree/-/espree-3.4.1.tgz",
-      "integrity": "sha1-KKg6tKrtce2P4PXv5ht2oFwTxNI=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+        "acorn": "5.3.0",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
-      "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esquery": {
-      "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
-      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.0"
       }
     },
     "estraverse": {
-      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-emitter": {
-      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-      },
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-          }
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-          "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-          "dev": true,
-          "requires": {
-            "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-            "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
-          }
-        }
+        "d": "1.0.0",
+        "es5-ext": "0.10.37"
       }
     },
     "events-to-array": {
-      "version": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
       "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true
     },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
     "exit-hook": {
-      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-levenshtein": {
-      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.0"
       }
     },
     "file-entry-cache": {
-      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.0"
       }
     },
     "find-root": {
-      "version": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
-      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "flat-cache": {
-      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "foreach": {
-      "version": "http://localhost:52225/foreach/-/foreach-2.0.5.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "foreground-child": {
-      "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        }
       }
     },
     "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "fs-access": {
-      "version": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
+        "null-check": "1.0.0"
       }
     },
     "fs-exists-cached": {
-      "version": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
       "dev": true
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
-      "version": "http://localhost:52225/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "function-loop": {
-      "version": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
       "integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw=",
       "dev": true
     },
     "generate-function": {
-      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
-      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+        "is-property": "1.0.2"
       }
     },
     "generic-pool": {
-      "version": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
       "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8=",
       "dev": true
     },
     "get-caller-file": {
-      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
     "get-pkg-repo": {
-      "version": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
-      "integrity": "sha1-Q8a0wEi3XdYE/FOI7ezeVX9jNd8=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+      "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-        "parse-github-repo-url": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-        "through2": "http://localhost:52225/through2/-/through2-2.0.1.tgz"
+        "hosted-git-info": "2.5.0",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.0",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "2.0.3"
       }
     },
     "get-stdin": {
-      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
     "getpass": {
-      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
-    "git-latest-semver-tag": {
-      "version": "https://registry.npmjs.org/git-latest-semver-tag/-/git-latest-semver-tag-1.0.2.tgz",
-      "integrity": "sha1-BhEwy/QnQRHMa+RhKz/zptk+JmA=",
-      "dev": true,
-      "requires": {
-        "git-semver-tags": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
-      }
-    },
     "git-raw-commits": {
-      "version": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
-      "integrity": "sha1-DzqL/ZmuDy2LkiTViJKXXppS0Dw=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
+      "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
       "dev": true,
       "requires": {
-        "dargs": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "split2": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-        "through2": "http://localhost:52225/through2/-/through2-2.0.1.tgz"
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
       }
     },
     "git-remote-origin-url": {
-      "version": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
       }
     },
     "git-semver-tags": {
-      "version": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.0.tgz",
-      "integrity": "sha1-sx/QLIq1eL1sm1ysyl4cZMEXesE=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
+      "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
       "dev": true,
       "requires": {
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        "meow": "3.7.0",
+        "semver": "5.4.1"
       },
       "dependencies": {
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "gitconfiglocal": {
-      "version": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+        "ini": "1.3.5"
       }
     },
-    "github-url-from-git": {
-      "version": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
-      "dev": true
-    },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
-      "version": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-      "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
-      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "handlebars": {
-      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          }
-        }
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       }
     },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "chalk": "1.1.3",
+        "commander": "2.12.2",
+        "is-my-json-valid": "2.17.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "has": {
-      "version": "http://localhost:52225/has/-/has-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "http://localhost:52225/function-bind/-/function-bind-1.1.0.tgz"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
-      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        "ansi-regex": "2.1.1"
       }
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hosted-git-info": {
-      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz"
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "ignore": {
-      "version": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-      "integrity": "sha1-SBDKXx2OylWVITo0uU8utO2Sa70=",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
-      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
-      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
-      "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "through": "http://localhost:52225/through/-/through-2.3.8.tgz"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       }
     },
     "interpret": {
-      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-      "integrity": "sha1-9PYj8LtxIvFfVxfI4lS4FhtcWy0=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invert-kv": {
-      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "is-arrayish": {
-      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
-      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
-      "version": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
     "is-date-object": {
-      "version": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-finite": {
-      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-my-json-valid": {
-      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
-        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-obj": {
-      "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-path-cwd": {
-      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-property": {
-      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regex": {
-      "version": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
-      "integrity": "sha1-DVUYK9358v3ieCIK7Dp1ZCyQhjc=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+        "has": "1.0.1"
       }
     },
+    "is-resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-subset": {
-      "version": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
-      "version": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-text-path": {
-      "version": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz"
+        "text-extensions": "1.7.0"
       }
     },
     "is-typedarray": {
-      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
-      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
-      "version": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
-      "version": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
       "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
     },
     "isexe": {
-      "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "items": {
-      "version": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
       "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
     },
-    "jodid25519": {
-      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "dev": true,
-      "optional": true,
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
       "requires": {
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+        "hoek": "4.2.0",
+        "isemail": "2.2.1",
+        "items": "2.1.1",
+        "topo": "2.0.2"
       }
     },
-    "joi": {
-      "version": "https://registry.npmjs.org/joi/-/joi-10.4.1.tgz",
-      "integrity": "sha1-ovyh8NYD0bhD8sHghrUkYfa+HzY=",
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
-        "isemail": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-        "items": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-        "topo": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
-          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok="
-        }
-      }
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+      "dev": true
     },
     "js-tokens": {
-      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-      "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
-      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
+    },
     "json-schema": {
-      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonparse": {
-      "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-      "integrity": "sha1-hfwkWx2SWazGlBlguQWt9k594Og=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
-      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "jsx-ast-utils": {
-      "version": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz",
-      "integrity": "sha1-Wv44ho9WvIzHrq7wEAuox1vRJZE=",
-      "dev": true,
-      "requires": {
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "dev": true
     },
     "kind-of": {
-      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
-      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
     },
     "lcid": {
-      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+        "invert-kv": "1.0.0"
       }
     },
     "lcov-parse": {
-      "version": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
     "levn": {
-      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
-      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "locate-path": {
-      "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
-          "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash._reinterpolate": {
-      "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
     "lodash.cond": {
-      "version": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
     "lodash.template": {
-      "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
-      "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "log-driver": {
-      "version": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "longest": {
-      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loud-rejection": {
-      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
-      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-        "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "map-obj": {
-      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
     "meow": {
-      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.0",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
       "dev": true
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+        "mime-db": "1.30.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
-    "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+    "minipass": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+      "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
       "dev": true,
       "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-      }
-    },
-    "modify-values": {
-      "version": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
-      "dev": true
-    },
-    "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-      "dev": true
-    },
-    "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
-    },
-    "natural-compare": {
-      "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "normalize-package-data": {
-      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-      "integrity": "sha1-SY+kIMlkAfeHQCuiHmAN75+YH/8=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-      }
-    },
-    "null-check": {
-      "version": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "https://registry.internal.npmjs.com/o/object-keys/_attachments/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true,
-      "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "function-bind": "http://localhost:52225/function-bind/-/function-bind-1.1.0.tgz",
-        "object-keys": "https://registry.internal.npmjs.com/o/object-keys/_attachments/object-keys-1.0.11.tgz"
-      }
-    },
-    "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-      }
-    },
-    "onetime": {
-      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
-    },
-    "only-shallow": {
-      "version": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
-      "integrity": "sha1-cc7O26kyS8BRiu8Q7AgNMkncJGU=",
-      "dev": true
-    },
-    "opener": {
-      "version": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
-      "dev": true
-    },
-    "optimist": {
-      "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        "yallist": "3.0.2"
       },
       "dependencies": {
-        "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
     },
-    "optionator": {
-      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+        "minimist": "0.0.8"
       }
     },
-    "os-homedir": {
-      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+    "modify-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
+      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
       "dev": true
     },
-    "os-locale": {
-      "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-      }
-    },
-    "own-or": {
-      "version": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-      "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "own-or-env": {
-      "version": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.0.tgz",
-      "integrity": "sha1-nvkg/IHi5jz1nUEQElg2jPT8pPs=",
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
-    "p-limit": {
-      "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "p-locate": {
-      "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.2",
+        "validate-npm-package-license": "3.0.1"
       }
     },
-    "packet-reader": {
-      "version": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
-      "integrity": "sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA=",
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
       "dev": true
     },
-    "parse-github-repo-url": {
-      "version": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
-      "integrity": "sha1-KGxT4smWLgZBZJ7jrJUI/KTdlZw=",
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "parse-json": {
-      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+    "nyc": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
       "dev": true,
       "requires": {
-        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
-      }
-    },
-    "path-exists": {
-      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
-    },
-    "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
-    },
-    "pg": {
-      "version": "https://registry.npmjs.org/pg/-/pg-6.1.5.tgz",
-      "integrity": "sha1-IE+kDBJSq3Ig189pkohrINd4Yrg=",
-      "dev": true,
-      "requires": {
-        "buffer-writer": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-        "packet-reader": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
-        "pg-connection-string": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-        "pg-pool": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.7.1.tgz",
-        "pg-types": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz",
-        "pgpass": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.1.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz"
-      }
-    },
-    "pg-connection-string": {
-      "version": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
-      "dev": true
-    },
-    "pg-cursor": {
-      "version": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-1.0.0.tgz",
-      "integrity": "sha1-tbS3vyd7NHjejBHN+dNLzaaXPA8="
-    },
-    "pg-pool": {
-      "version": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.7.1.tgz",
-      "integrity": "sha1-QhEFy3Rpl53MSNb8T+P+RllDdDc=",
-      "dev": true,
-      "requires": {
-        "generic-pool": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-      }
-    },
-    "pg-query-stream": {
-      "version": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-1.0.0.tgz",
-      "integrity": "sha1-qbNNpcgcCkw3sosa81JZ6JQw/Jg=",
-      "requires": {
-        "pg-cursor": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-1.0.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-      }
-    },
-    "pg-types": {
-      "version": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz",
-      "integrity": "sha1-qukagtlStjO7iNAGNQoWbar26pA=",
-      "dev": true,
-      "requires": {
-        "ap": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
-        "postgres-array": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
-        "postgres-bytea": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-        "postgres-date": "https://registry.internal.npmjs.com/p/postgres-date/_attachments/postgres-date-1.0.3.tgz",
-        "postgres-interval": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz"
-      }
-    },
-    "pgpass": {
-      "version": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.1.tgz",
-      "integrity": "sha1-Dei1vvmTKV2Qp+F9l29Wjc0l1J8=",
-      "dev": true,
-      "requires": {
-        "split": "https://registry.npmjs.org/split/-/split-1.0.0.tgz"
-      }
-    },
-    "pify": {
-      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-      }
-    },
-    "pkg-conf": {
-      "version": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
-      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz"
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-lib-source-maps": "1.2.2",
+        "istanbul-reports": "1.1.3",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.4",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.1.1",
+        "yargs": "10.0.3",
+        "yargs-parser": "8.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
-          }
-        }
-      }
-    },
-    "pkg-config": {
-      "version": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-        "find-root": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
-    },
-    "pkg-dir": {
-      "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-      }
-    },
-    "pkg-up": {
-      "version": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-      }
-    },
-    "pluralize": {
-      "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-      "dev": true
-    },
-    "postgres-array": {
-      "version": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
-      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg=",
-      "dev": true
-    },
-    "postgres-bytea": {
-      "version": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
-      "dev": true
-    },
-    "postgres-date": {
-      "version": "https://registry.internal.npmjs.com/p/postgres-date/_attachments/postgres-date-1.0.3.tgz",
-      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=",
-      "dev": true
-    },
-    "postgres-interval": {
-      "version": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz",
-      "integrity": "sha1-cmFDjYYrQSkhxv23YXZoQktzpu0=",
-      "dev": true,
-      "requires": {
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
-    },
-    "prelude-ls": {
-      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "progress": {
-      "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
-    },
-    "q": {
-      "version": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-      "dev": true
-    },
-    "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-      "dev": true
-    },
-    "quotemeta": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
-      "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
-    },
-    "read-pkg": {
-      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-          }
-        },
-        "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-          }
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-      }
-    },
-    "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-      "requires": {
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz",
-        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      }
-    },
-    "readline2": {
-      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-      }
-    },
-    "rechoir": {
-      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-      }
-    },
-    "redent": {
-      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-      }
-    },
-    "repeat-string": {
-      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "repeating": {
-      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-      }
-    },
-    "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-      }
-    },
-    "require-directory": {
-      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "require-uncached": {
-      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-      }
-    },
-    "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
-    },
-    "resolve-from": {
-      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-      }
-    },
-    "right-align": {
-      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-      }
-    },
-    "rimraf": {
-      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-      }
-    },
-    "run-async": {
-      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-      }
-    },
-    "run-parallel": {
-      "version": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
-      "dev": true
-    },
-    "rx-lite": {
-      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
-    },
-    "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "shelljs": {
-      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
-      "dev": true,
-      "requires": {
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz",
-        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-      }
-    },
-    "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
-    },
-    "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
-    },
-    "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
-      "integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
-      "dev": true,
-      "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-      }
-    },
-    "spdx-correct": {
-      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-      }
-    },
-    "spdx-expression-parse": {
-      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
-    },
-    "spdx-license-ids": {
-      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
-    },
-    "split": {
-      "version": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
-      "dev": true,
-      "requires": {
-        "through": "http://localhost:52225/through/-/through-2.3.8.tgz"
-      }
-    },
-    "split2": {
-      "version": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-      "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
-      "dev": true,
-      "requires": {
-        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-          }
-        },
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          }
-        }
-      }
-    },
-    "sprintf-js": {
-      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "sqlite3": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.13.tgz",
-      "integrity": "sha512-JxXKPJnkZ6NuHRojq+g2WXWBt3M1G9sjZaYiHEWSTGijDM3cwju/0T2XbWqMXFmPqDgw+iB7zKQvnns4bvzXlw==",
-      "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.38"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ajv": {
-          "version": "4.11.8",
+        "align-text": {
+          "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
           "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
+            "default-require-extensions": "1.0.0"
           }
         },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
         },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
         },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
         },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
         },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
           "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
         },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
           "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
           "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
+          "dev": true
         },
-        "dashdash": {
-          "version": "1.14.1",
+        "convert-source-map": {
+          "version": "1.5.1",
           "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
           }
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
+        "debug-log": {
+          "version": "1.0.1",
           "bundled": true,
-          "optional": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "strip-bom": "2.0.0"
           }
         },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.1.4",
+        "detect-indent": {
+          "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
           "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
+          "dev": true
         },
-        "fstream-ignore": {
-          "version": "1.0.5",
+        "get-caller-file": {
+          "version": "1.0.2",
           "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "dev": true
         },
-        "gauge": {
-          "version": "2.7.4",
+        "get-stream": {
+          "version": "3.0.0",
           "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3090,52 +2801,81 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
           "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
           }
         },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "hawk": {
-          "version": "3.1.3",
+        "has-ansi": {
+          "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "ansi-regex": "2.1.1"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "has-flag": {
+          "version": "1.0.0",
           "bundled": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -3143,2380 +2883,3240 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
         },
-        "is-fullwidth-code-point": {
+        "invert-kv": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
-        "is-typedarray": {
+        "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
           "bundled": true,
-          "optional": true
+          "dev": true
         },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
+        "isexe": {
+          "version": "2.0.0",
           "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "isarray": "1.0.0"
           }
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
           "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.4.1"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
             }
           }
         },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
+        "istanbul-lib-source-maps": {
+          "version": "1.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
+        },
+        "istanbul-reports": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.38",
           "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.2",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.2",
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
             "semver": "5.4.1",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "validate-npm-package-license": "3.0.1"
           }
         },
-        "nopt": {
-          "version": "4.0.1",
+        "normalize-path": {
+          "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.4"
+            "remove-trailing-separator": "1.1.0"
           }
         },
-        "npmlog": {
-          "version": "4.1.2",
+        "npm-run-path": {
+          "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.4",
           "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.1",
           "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
           },
           "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
             }
           }
         },
-        "readable-stream": {
-          "version": "2.3.3",
+        "preserve": {
+          "version": "0.2.0",
           "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
           }
         },
-        "request": {
-          "version": "2.81.0",
+        "read-pkg": {
+          "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
         "semver": {
           "version": "5.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "1.0.9",
           "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
           }
         },
-        "sshpk": {
-          "version": "1.13.1",
+        "spdx-correct": {
+          "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
             }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.0.0"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
+    "own-or": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
+      "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+      "dev": true
+    },
+    "own-or-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.0.tgz",
+      "integrity": "sha1-nvkg/IHi5jz1nUEQElg2jPT8pPs=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
+    },
+    "packet-reader": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
+      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=",
+      "dev": true
+    },
+    "parse-github-repo-url": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1",
+        "json-parse-better-errors": "1.0.1"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "pg": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
+      "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "1.0.1",
+        "js-string-escape": "1.0.1",
+        "packet-reader": "0.3.1",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "1.8.0",
+        "pg-types": "1.13.0",
+        "pgpass": "1.0.2",
+        "semver": "4.3.2"
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+      "dev": true
+    },
+    "pg-cursor": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-1.3.0.tgz",
+      "integrity": "sha1-siDxkIl2t7QNqjc8etpfyoI6sNk="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
+      "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
+      "dev": true,
+      "requires": {
+        "generic-pool": "2.4.3",
+        "object-assign": "4.1.0"
+      }
+    },
+    "pg-query-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-1.1.1.tgz",
+      "integrity": "sha1-Zel0Nu+AnR4WDrqE6/EbnkdC6rQ=",
+      "requires": {
+        "pg-cursor": "1.3.0"
+      }
+    },
+    "pg-types": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
+      "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "1.0.2",
+        "postgres-bytea": "1.0.0",
+        "postgres-date": "1.0.3",
+        "postgres-interval": "1.1.1"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
+      "requires": {
+        "split": "1.0.1"
+      }
+    },
+    "pgtools": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pgtools/-/pgtools-0.3.0.tgz",
+      "integrity": "sha512-8NxDCJ8xJ6hOp9hVNZqxi+TZl7hM1Jc8pQyj8DlAbyaWnk5OsGwf3gB/UyDODdOguiim9QzbzPsslp//apO+Uw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "pg": "6.4.2",
+        "pg-connection-string": "0.1.3",
+        "yargs": "5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "buffer-writer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+          "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
+          "dev": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "generic-pool": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
+          "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8=",
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "4.3.2",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "packet-reader": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
+          "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pg": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
+          "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+          "dev": true,
+          "requires": {
+            "buffer-writer": "1.0.1",
+            "js-string-escape": "1.0.1",
+            "packet-reader": "0.3.1",
+            "pg-connection-string": "0.1.3",
+            "pg-pool": "1.8.0",
+            "pg-types": "1.13.0",
+            "pgpass": "1.0.2",
+            "semver": "4.3.2"
+          }
+        },
+        "pg-connection-string": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+          "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+          "dev": true
+        },
+        "pg-pool": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
+          "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
+          "dev": true,
+          "requires": {
+            "generic-pool": "2.4.3",
+            "object-assign": "4.1.0"
+          }
+        },
+        "pg-types": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
+          "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+          "dev": true,
+          "requires": {
+            "pg-int8": "1.0.1",
+            "postgres-array": "1.0.2",
+            "postgres-bytea": "1.0.0",
+            "postgres-date": "1.0.3",
+            "postgres-interval": "1.1.1"
+          }
+        },
+        "pgpass": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+          "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+          "dev": true,
+          "requires": {
+            "split": "1.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "postgres-array": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
+          "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg=",
+          "dev": true
+        },
+        "postgres-bytea": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+          "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+          "dev": true
+        },
+        "postgres-date": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+          "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=",
+          "dev": true
+        },
+        "postgres-interval": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
+          "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+          "dev": true,
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "dev": true
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "dev": true,
+          "requires": {
+            "through": "2.3.8"
           }
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "is-utf8": "0.2.1"
           }
         },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.3",
-            "rimraf": "2.6.2",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
           }
         },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           }
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
+          "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
+          "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "3.2.0"
           }
         },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
+        "yargs-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
+          "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
+          "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            }
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
         }
       }
     },
-    "sshpk": {
-      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-        "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-conf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "load-json-file": "4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pkg-up": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "postgres-array": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
+      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg=",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
+      "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+      "dev": true,
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "quotemeta": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
+      "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "semver": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "requires": {
+        "through2": "2.0.3"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "stack-utils": {
-      "version": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.0.tgz",
-      "integrity": "sha1-I5LNjdvSIkku1sBHlg90FLRsD4M=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
     "standard": {
-      "version": "https://registry.npmjs.org/standard/-/standard-10.0.1.tgz",
-      "integrity": "sha1-mcFXj8yo1vVM6MJxH1RSRD6DkII=",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
-        "eslint": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-        "eslint-config-standard": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.0.tgz",
-        "eslint-config-standard-jsx": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.1.tgz",
-        "eslint-plugin-import": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
-        "eslint-plugin-node": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz",
-        "eslint-plugin-promise": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-        "eslint-plugin-react": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-        "eslint-plugin-standard": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-        "standard-engine": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz"
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-config-standard-jsx": "4.0.2",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-node": "4.2.3",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-react": "6.10.3",
+        "eslint-plugin-standard": "3.0.1",
+        "standard-engine": "7.0.0"
       }
     },
     "standard-engine": {
-      "version": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
       "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
       "dev": true,
       "requires": {
-        "deglob": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "pkg-conf": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz"
+        "deglob": "2.1.0",
+        "get-stdin": "5.0.1",
+        "minimist": "1.2.0",
+        "pkg-conf": "2.1.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "standard-version": {
-      "version": "https://registry.npmjs.org/standard-version/-/standard-version-4.0.0.tgz",
-      "integrity": "sha1-5XjO/UOrewKUS9dWlSUFLqwbl4c=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.2.0.tgz",
+      "integrity": "sha1-MBfoxc7SqS23UBeQJVw7qFFXN10=",
       "dev": true,
       "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "conventional-changelog": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.3.tgz",
-        "conventional-recommended-bump": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-0.3.0.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-        "fs-access": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz"
+        "chalk": "1.1.3",
+        "conventional-changelog": "1.1.7",
+        "conventional-recommended-bump": "1.1.0",
+        "figures": "1.7.0",
+        "fs-access": "1.0.1",
+        "semver": "5.4.1",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "string-width": {
-      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-indent": {
-      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        "get-stdin": "4.0.1"
       },
       "dependencies": {
         "get-stdin": {
-          "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
         }
       }
     },
     "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "table": {
-      "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz",
-        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
           }
         }
       }
     },
     "tap": {
-      "version": "https://registry.npmjs.org/tap/-/tap-10.3.2.tgz",
-      "integrity": "sha1-d5gvCDaNixgDo7CrX8MA4YF/Mec=",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-11.0.1.tgz",
+      "integrity": "sha512-YfrPp7FFxASC4tK4DEAKnnTxyg+J7T8kh8NiOmICNhiGvSojPAV34Ir4DDElFvnIiDEMzDP7233lw3WacFvIFQ==",
       "dev": true,
       "requires": {
-        "bind-obj-methods": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
-        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-        "clean-yaml-object": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-        "color-support": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz",
-        "coveralls": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
-        "deeper": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
-        "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-        "fs-exists-cached": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
-        "function-loop": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-        "nyc": "https://registry.npmjs.org/nyc/-/nyc-10.2.0.tgz",
-        "only-shallow": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
-        "opener": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-        "own-or": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-        "own-or-env": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
-        "stack-utils": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.0.tgz",
-        "tap-mocha-reporter": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.3.tgz",
-        "tap-parser": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.3.3.tgz",
-        "tmatch": "https://registry.npmjs.org/tmatch/-/tmatch-3.0.0.tgz",
-        "trivial-deferred": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
-        "yapool": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz"
-      },
-      "dependencies": {
-        "nyc": {
-          "version": "https://registry.npmjs.org/nyc/-/nyc-10.2.0.tgz",
-          "integrity": "sha1-+s2QJAYAyapN2B6pnC+2qFxT3gw=",
-          "dev": true,
-          "requires": {
-            "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz",
-            "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-            "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-            "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz",
-            "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.5.tgz",
-            "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-            "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0.tgz",
-            "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.1.tgz",
-            "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.2.tgz",
-            "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-            "merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
-            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "spawn-wrap": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-            "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.0.3.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-7.0.2.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
-          },
-          "dependencies": {
-            "align-text": {
-              "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-              "dev": true,
-              "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-              }
-            },
-            "amdefine": {
-              "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-              "dev": true
-            },
-            "append-transform": {
-              "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-              "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-              "dev": true,
-              "requires": {
-                "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
-              }
-            },
-            "archy": {
-              "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-              "dev": true
-            },
-            "arr-diff": {
-              "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-              "dev": true,
-              "requires": {
-                "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-              }
-            },
-            "arr-flatten": {
-              "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-              "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
-              "dev": true
-            },
-            "array-unique": {
-              "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-              "dev": true
-            },
-            "arrify": {
-              "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-              "dev": true
-            },
-            "async": {
-              "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-              "dev": true
-            },
-            "babel-code-frame": {
-              "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-              "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-              "dev": true,
-              "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-              }
-            },
-            "babel-generator": {
-              "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.0.tgz",
-              "integrity": "sha1-66JwqMxM5uCaYb5DRl18YsH4fFY=",
-              "dev": true,
-              "requires": {
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
-                "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-                "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-              }
-            },
-            "babel-messages": {
-              "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-              "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-              "dev": true,
-              "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-              }
-            },
-            "babel-runtime": {
-              "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-              "dev": true,
-              "requires": {
-                "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-                "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
-              }
-            },
-            "babel-template": {
-              "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
-              "integrity": "sha1-BNTycK27OqcEqBQ64m+qUpI45jg=",
-              "dev": true,
-              "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-              }
-            },
-            "babel-traverse": {
-              "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
-              "integrity": "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g=",
-              "dev": true,
-              "requires": {
-                "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
-                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-                "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-                "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-              }
-            },
-            "babel-types": {
-              "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
-              "integrity": "sha1-uxcXnXU4utOM0MnhFdNA935+ms8=",
-              "dev": true,
-              "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-              }
-            },
-            "babylon": {
-              "version": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
-              "integrity": "sha1-MMWiL0gZeKnn+M399JaxHZS0BNM=",
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-              "dev": true
-            },
-            "brace-expansion": {
-              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-              "dev": true,
-              "requires": {
-                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-              }
-            },
-            "braces": {
-              "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-              "dev": true,
-              "requires": {
-                "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-              }
-            },
-            "builtin-modules": {
-              "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-              "dev": true
-            },
-            "caching-transform": {
-              "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-              "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-              "dev": true,
-              "requires": {
-                "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz"
-              }
-            },
-            "camelcase": {
-              "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-              "dev": true,
-              "optional": true
-            },
-            "center-align": {
-              "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-              }
-            },
-            "chalk": {
-              "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-              }
-            },
-            "cliui": {
-              "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true
-            },
-            "commondir": {
-              "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-              "dev": true
-            },
-            "concat-map": {
-              "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
-            },
-            "convert-source-map": {
-              "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz",
-              "integrity": "sha1-49rRlb9hv+E6ejxz6YduwUoCaPM=",
-              "dev": true
-            },
-            "core-js": {
-              "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-              "dev": true
-            },
-            "cross-spawn": {
-              "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-              "dev": true,
-              "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-              }
-            },
-            "debug": {
-              "version": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-              "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
-              "dev": true,
-              "requires": {
-                "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-              }
-            },
-            "debug-log": {
-              "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-              "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-              "dev": true
-            },
-            "decamelize": {
-              "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-              "dev": true
-            },
-            "default-require-extensions": {
-              "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-              "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-              "dev": true,
-              "requires": {
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-              }
-            },
-            "detect-indent": {
-              "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-              "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-              "dev": true,
-              "requires": {
-                "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-              }
-            },
-            "error-ex": {
-              "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-              "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-              "dev": true,
-              "requires": {
-                "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            },
-            "esutils": {
-              "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-              "dev": true
-            },
-            "expand-brackets": {
-              "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-              "dev": true,
-              "requires": {
-                "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-              }
-            },
-            "expand-range": {
-              "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-              "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-              "dev": true,
-              "requires": {
-                "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-              }
-            },
-            "extglob": {
-              "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-              }
-            },
-            "filename-regex": {
-              "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
-              "dev": true
-            },
-            "fill-range": {
-              "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-              "dev": true,
-              "requires": {
-                "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-              }
-            },
-            "find-cache-dir": {
-              "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-              "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-              "dev": true,
-              "requires": {
-                "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-              }
-            },
-            "find-up": {
-              "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-              }
-            },
-            "for-in": {
-              "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-              "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-              "dev": true
-            },
-            "for-own": {
-              "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-              "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-              "dev": true,
-              "requires": {
-                "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-              }
-            },
-            "foreground-child": {
-              "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-              "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-              "dev": true,
-              "requires": {
-                "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-              }
-            },
-            "fs.realpath": {
-              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
-            },
-            "get-caller-file": {
-              "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-              "dev": true
-            },
-            "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-              }
-            },
-            "glob-base": {
-              "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-              "dev": true,
-              "requires": {
-                "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-              }
-            },
-            "glob-parent": {
-              "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-              "dev": true,
-              "requires": {
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-              }
-            },
-            "globals": {
-              "version": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-              "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
-              "dev": true
-            },
-            "graceful-fs": {
-              "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-              "dev": true
-            },
-            "handlebars": {
-              "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-              "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
-              "dev": true,
-              "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.16.tgz"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                  "dev": true,
-                  "requires": {
-                    "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                  }
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-              }
-            },
-            "has-flag": {
-              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-              "dev": true
-            },
-            "hosted-git-info": {
-              "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
-              "integrity": "sha1-SwRF5BwASovRM3dzpP95DKQDGMg=",
-              "dev": true
-            },
-            "imurmurhash": {
-              "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-              "dev": true
-            },
-            "inflight": {
-              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
-              "requires": {
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-              }
-            },
-            "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "invariant": {
-              "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-              "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-              "dev": true,
-              "requires": {
-                "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
-              }
-            },
-            "invert-kv": {
-              "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-              "dev": true
-            },
-            "is-arrayish": {
-              "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-              "dev": true
-            },
-            "is-buffer": {
-              "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-              "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-              "dev": true
-            },
-            "is-builtin-module": {
-              "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-              "dev": true,
-              "requires": {
-                "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-              }
-            },
-            "is-dotfile": {
-              "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-              "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
-              "dev": true
-            },
-            "is-equal-shallow": {
-              "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-              "dev": true,
-              "requires": {
-                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-              }
-            },
-            "is-extendable": {
-              "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-              "dev": true
-            },
-            "is-extglob": {
-              "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-              "dev": true
-            },
-            "is-finite": {
-              "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-              "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-              }
-            },
-            "is-glob": {
-              "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-              }
-            },
-            "is-number": {
-              "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-              "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-              "dev": true,
-              "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-              "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-              "dev": true
-            },
-            "is-primitive": {
-              "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-              "dev": true
-            },
-            "is-utf8": {
-              "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-              "dev": true
-            },
-            "isarray": {
-              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "isexe": {
-              "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
-            },
-            "isobject": {
-              "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
-              "requires": {
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-              }
-            },
-            "istanbul-lib-coverage": {
-              "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz",
-              "integrity": "sha1-h6DAFbaRBlHLOxhIFN+zOTN+JeE=",
-              "dev": true
-            },
-            "istanbul-lib-hook": {
-              "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.5.tgz",
-              "integrity": "sha1-bKPRbWDF9Agto598XNOOqKdyuI4=",
-              "dev": true,
-              "requires": {
-                "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
-              }
-            },
-            "istanbul-lib-instrument": {
-              "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-              "integrity": "sha1-uODcJXCbtE4XM2q0e3u1yXwj9lk=",
-              "dev": true,
-              "requires": {
-                "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
-                "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-              }
-            },
-            "istanbul-lib-report": {
-              "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.0.0.tgz",
-              "integrity": "sha1-2D2sfyZWa1IVhVaTZ/6EzPx6rss=",
-              "dev": true,
-              "requires": {
-                "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                  }
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.1.tgz",
-              "integrity": "sha1-+MjC6PIWDR2RUm2X5b1jsgea9xw=",
-              "dev": true,
-              "requires": {
-                "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-              }
-            },
-            "istanbul-reports": {
-              "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.0.2.tgz",
-              "integrity": "sha1-ToNmq+b6dGzBzWYz8QjeEsxqxvo=",
-              "dev": true,
-              "requires": {
-                "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz"
-              }
-            },
-            "js-tokens": {
-              "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-              "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-              "dev": true
-            },
-            "jsesc": {
-              "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-              "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-              "dev": true
-            },
-            "kind-of": {
-              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-              "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-              }
-            },
-            "lazy-cache": {
-              "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-              "dev": true,
-              "optional": true
-            },
-            "lcid": {
-              "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-              "dev": true,
-              "requires": {
-                "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-              }
-            },
-            "load-json-file": {
-              "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-              }
-            },
-            "lodash": {
-              "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-              "dev": true
-            },
-            "longest": {
-              "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-              "dev": true
-            },
-            "loose-envify": {
-              "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-              "dev": true,
-              "requires": {
-                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-              }
-            },
-            "lru-cache": {
-              "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-              "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-              "dev": true,
-              "requires": {
-                "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-              }
-            },
-            "md5-hex": {
-              "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-              "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-              "dev": true,
-              "requires": {
-                "md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-              }
-            },
-            "md5-o-matic": {
-              "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-              "dev": true
-            },
-            "merge-source-map": {
-              "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
-              "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
-              "dev": true,
-              "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-              }
-            },
-            "micromatch": {
-              "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-              "dev": true,
-              "requires": {
-                "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-              }
-            },
-            "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-              }
-            },
-            "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            },
-            "mkdirp": {
-              "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-              }
-            },
-            "ms": {
-              "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
-            },
-            "normalize-package-data": {
-              "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-              "integrity": "sha1-SY+kIMlkAfeHQCuiHmAN75+YH/8=",
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
-                "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-              }
-            },
-            "normalize-path": {
-              "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
-              "dev": true
-            },
-            "number-is-nan": {
-              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true
-            },
-            "object-assign": {
-              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            },
-            "object.omit": {
-              "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-              "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-              "dev": true,
-              "requires": {
-                "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-              }
-            },
-            "once": {
-              "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
-              "requires": {
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-              }
-            },
-            "optimist": {
-              "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "dev": true,
-              "requires": {
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-              }
-            },
-            "os-homedir": {
-              "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "dev": true
-            },
-            "os-locale": {
-              "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-              "dev": true,
-              "requires": {
-                "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
-              }
-            },
-            "parse-glob": {
-              "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-              "dev": true,
-              "requires": {
-                "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-              }
-            },
-            "parse-json": {
-              "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-              "dev": true,
-              "requires": {
-                "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
-              }
-            },
-            "path-exists": {
-              "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-              "dev": true,
-              "requires": {
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-              }
-            },
-            "path-is-absolute": {
-              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
-            },
-            "path-parse": {
-              "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-              "dev": true
-            },
-            "path-type": {
-              "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-              }
-            },
-            "pify": {
-              "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            },
-            "pinkie": {
-              "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-              }
-            },
-            "pkg-dir": {
-              "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-              "dev": true,
-              "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-              }
-            },
-            "preserve": {
-              "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-              "dev": true
-            },
-            "pseudomap": {
-              "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-              "dev": true
-            },
-            "randomatic": {
-              "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-              "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-              "dev": true,
-              "requires": {
-                "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
-              }
-            },
-            "read-pkg": {
-              "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-              "dev": true,
-              "requires": {
-                "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-                "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-              }
-            },
-            "read-pkg-up": {
-              "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-              "dev": true,
-              "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-              }
-            },
-            "regenerator-runtime": {
-              "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
-              "integrity": "sha1-jENnqQS1HqYqkIrDEL+Z/5CoKj4=",
-              "dev": true
-            },
-            "regex-cache": {
-              "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-              "dev": true,
-              "requires": {
-                "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-              }
-            },
-            "repeat-element": {
-              "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-              "dev": true
-            },
-            "repeat-string": {
-              "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-              "dev": true
-            },
-            "repeating": {
-              "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-              "dev": true,
-              "requires": {
-                "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-              }
-            },
-            "require-directory": {
-              "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-              "dev": true
-            },
-            "require-main-filename": {
-              "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-              "dev": true
-            },
-            "resolve-from": {
-              "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-              "dev": true
-            },
-            "right-align": {
-              "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-              }
-            },
-            "rimraf": {
-              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-              "dev": true,
-              "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-              }
-            },
-            "semver": {
-              "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-              "dev": true
-            },
-            "set-blocking": {
-              "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-              "dev": true
-            },
-            "slide": {
-              "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-              "dev": true
-            },
-            "source-map": {
-              "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-              "dev": true
-            },
-            "spawn-wrap": {
-              "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
-              "integrity": "sha1-kg6yEadpwJPuv71bDnpdLmirLkA=",
-              "dev": true,
-              "requires": {
-                "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-              },
-              "dependencies": {
-                "signal-exit": {
-                  "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                  "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
-                  "dev": true
-                }
-              }
-            },
-            "spdx-correct": {
-              "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-              "dev": true,
-              "requires": {
-                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-              "dev": true
-            },
-            "spdx-license-ids": {
-              "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-              }
-            },
-            "strip-ansi": {
-              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-              }
-            },
-            "strip-bom": {
-              "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "dev": true,
-              "requires": {
-                "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-              }
-            },
-            "supports-color": {
-              "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            },
-            "test-exclude": {
-              "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.0.3.tgz",
-              "integrity": "sha1-hqE84+/8xg5skEA88xonpgrGxOc=",
-              "dev": true,
-              "requires": {
-                "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-              }
-            },
-            "to-fast-properties": {
-              "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-              "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA=",
-              "dev": true
-            },
-            "trim-right": {
-              "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-              "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-              "dev": true
-            },
-            "uglify-js": {
-              "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.16.tgz",
-              "integrity": "sha1-0oYZC27vxv1l6w7KxlUeCw6IOaQ=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-              },
-              "dependencies": {
-                "yargs": {
-                  "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                    "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                    "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                  }
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-              "dev": true,
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-              "dev": true,
-              "requires": {
-                "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-              }
-            },
-            "which": {
-              "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-              "dev": true,
-              "requires": {
-                "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-              }
-            },
-            "which-module": {
-              "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-              "dev": true
-            },
-            "window-size": {
-              "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-              "dev": true,
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-              "dev": true
-            },
-            "wrap-ansi": {
-              "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-              "dev": true,
-              "requires": {
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-              }
-            },
-            "wrappy": {
-              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
-            },
-            "write-file-atomic": {
-              "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-              "integrity": "sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-              }
-            },
-            "y18n": {
-              "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-              "dev": true
-            },
-            "yallist": {
-              "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-              "dev": true
-            },
-            "yargs": {
-              "version": "https://registry.npmjs.org/yargs/-/yargs-7.0.2.tgz",
-              "integrity": "sha1-EVuX3xMhgj6Lhkjolox4JSEiH2c=",
-              "dev": true,
-              "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-                "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-                "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-                "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                  "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                  "dev": true
-                },
-                "cliui": {
-                  "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                  "dev": true,
-                  "requires": {
-                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-                  }
-                },
-                "yargs-parser": {
-                  "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-                  "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-                  "dev": true,
-                  "requires": {
-                    "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-                  }
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-              "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-              "dev": true,
-              "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                  "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "os-homedir": {
-          "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-          "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
-          "dev": true
-        }
+        "bind-obj-methods": "1.0.0",
+        "bluebird": "3.5.1",
+        "clean-yaml-object": "0.1.0",
+        "color-support": "1.1.3",
+        "coveralls": "2.13.3",
+        "foreground-child": "1.5.6",
+        "fs-exists-cached": "1.0.0",
+        "function-loop": "1.0.1",
+        "glob": "7.1.2",
+        "isexe": "2.0.0",
+        "js-yaml": "3.10.0",
+        "minipass": "2.2.1",
+        "mkdirp": "0.5.1",
+        "nyc": "11.4.1",
+        "opener": "1.4.3",
+        "os-homedir": "1.0.2",
+        "own-or": "1.0.0",
+        "own-or-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "source-map-support": "0.4.18",
+        "stack-utils": "1.0.1",
+        "tap-mocha-reporter": "3.0.6",
+        "tap-parser": "7.0.0",
+        "tmatch": "3.1.0",
+        "trivial-deferred": "1.0.1",
+        "tsame": "1.1.2",
+        "write-file-atomic": "2.3.0",
+        "yapool": "1.0.0"
       }
     },
     "tap-mocha-reporter": {
-      "version": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.3.tgz",
-      "integrity": "sha1-5ZF/rT2acJV/m3xzbnk764fX2vE=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.6.tgz",
+      "integrity": "sha512-UImgw3etckDQCoqZIAIKcQDt0w1JLVs3v0yxLlmwvGLZl6MGFxF7JME5PElXjAoDklVDU42P3vVu5jgr37P4Yg==",
       "dev": true,
       "requires": {
-        "color-support": "https://registry.npmjs.org/color-support/-/color-support-1.1.2.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-        "tap-parser": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.3.3.tgz",
-        "unicode-length": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz"
+        "color-support": "1.1.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "readable-stream": "2.3.3",
+        "tap-parser": "5.4.0",
+        "unicode-length": "1.0.3"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+        "tap-parser": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+          "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "http://localhost:52225/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+            "events-to-array": "1.1.2",
+            "js-yaml": "3.10.0",
+            "readable-stream": "2.3.3"
           }
         }
       }
     },
     "tap-parser": {
-      "version": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.3.3.tgz",
-      "integrity": "sha1-U+yKkPJ11v/0PxaeVqZ5UCp0EYU=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
+      "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
       "dev": true,
       "requires": {
-        "events-to-array": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        "events-to-array": "1.1.2",
+        "js-yaml": "3.10.0",
+        "minipass": "2.2.1"
       }
     },
     "text-extensions": {
-      "version": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz",
-      "integrity": "sha1-w4XS6Ah5/m75eJPhcJ2I2UU3Juk=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
       "dev": true
     },
     "text-table": {
-      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
-      "version": "http://localhost:52225/through/-/through-2.3.8.tgz",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
-      "version": "http://localhost:52225/through2/-/through2-2.0.1.tgz",
-      "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       }
     },
     "tmatch": {
-      "version": "https://registry.npmjs.org/tmatch/-/tmatch-3.0.0.tgz",
-      "integrity": "sha1-fSBx3tu8WH8ZSs2jBnvQdHtnCZE=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
+      "integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ==",
       "dev": true
     },
     "topo": {
-      "version": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
-          "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok="
-        }
+        "hoek": "4.2.0"
       }
     },
     "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+        "punycode": "1.4.1"
       }
     },
     "trim-newlines": {
-      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "trim-off-newlines": {
-      "version": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
     "trivial-deferred": {
-      "version": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
       "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
       "dev": true
     },
-    "tryit": {
-      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+    "tsame": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tsame/-/tsame-1.1.2.tgz",
+      "integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw==",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
     "tweetnacl": {
-      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
-      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
-      "version": "http://localhost:52225/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
-      "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        },
         "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
           }
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "unicode-length": {
-      "version": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
       "dev": true,
       "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
       }
     },
     "uniq": {
-      "version": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "user-home": {
-      "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+        "os-homedir": "1.0.2"
       }
     },
     "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-      }
-    },
-    "weallbehave": {
-      "version": "https://registry.npmjs.org/weallbehave/-/weallbehave-1.0.3.tgz",
-      "integrity": "sha1-U6aAMyiP15NsKE3joKe3GmQQwxI=",
-      "dev": true,
-      "requires": {
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz"
-      }
-    },
-    "weallcontribute": {
-      "version": "https://registry.npmjs.org/weallcontribute/-/weallcontribute-1.0.8.tgz",
-      "integrity": "sha1-kYAe6ysQBnjoRLcgvdh1Q8Mc2Qo=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz"
-      }
-    },
-    "which": {
-      "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
-      "requires": {
-        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
       },
       "dependencies": {
-        "isexe": {
-          "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
+    "weallbehave": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/weallbehave/-/weallbehave-1.2.0.tgz",
+      "integrity": "sha1-hR79VUAlo06O8kmeR4DEQHcyFhs=",
+      "dev": true,
+      "requires": {
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
+    "weallcontribute": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/weallcontribute/-/weallcontribute-1.0.8.tgz",
+      "integrity": "sha1-kYAe6ysQBnjoRLcgvdh1Q8Mc2Qo=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
     "which-module": {
-      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "window-size": {
-      "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
     },
     "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
-      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        "mkdirp": "0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
-      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
-      "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yapool": {
-      "version": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
       "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
       "dev": true
     },
     "yargs": {
-      "version": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-        "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-        "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-        "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-        "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "cliui": {
-          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
           }
         }
       }
     },
     "yargs-parser": {
-      "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "pretest": "node -e 'require(\"./test/db\").createdb()'",
     "test": "TZ=UTC tap test/*-test.js",
     "posttest": "standard",
-    "test-cov": "TZ=UTC tap --cov test/*-test.js"
+    "test-cov": "TZ=UTC tap --cov test/*-test.js",
+    "test-cov-html": "TZ=UTC tap --coverage-report=html test/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@iterables/zip": "^1.0.2",
     "bluebird": "^3.4.6",
     "concat-stream": "^1.6.0",
-    "joi": "^10.4.1",
+    "joi": "^13.1.0",
     "pg-query-stream": "^1.0.0",
     "quotemeta": "0.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "prerelease": "npm run update-contrib && npm run update-coc",
     "release": "standard-version",
+    "pretest": "TZ=UTC node -e 'require(\"./test/db\").createdb()'",
     "test": "TZ=UTC tap test/*-test.js",
     "posttest": "standard",
     "test-cov": "TZ=UTC tap --cov test/*-test.js"
@@ -38,9 +39,10 @@
   },
   "devDependencies": {
     "pg": "^6.1.5",
+    "pgtools": "^0.3.0",
     "standard": "^10.0.1",
     "standard-version": "^4.0.0",
-    "tap": "^10.3.2",
+    "tap": "^11.0.1",
     "weallbehave": "^1.0.3",
     "weallcontribute": "^1.0.8"
   }

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "quotemeta": "0.0.0"
   },
   "devDependencies": {
-    "pg": "^6.1.5",
+    "pg": "^7.4.1",
     "pgtools": "^0.3.0",
     "standard": "^10.0.1",
-    "standard-version": "^4.0.0",
+    "standard-version": "^4.3.0",
     "tap": "^11.0.1",
     "weallbehave": "^1.0.3",
     "weallcontribute": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "prerelease": "npm run update-contrib && npm run update-coc",
     "release": "standard-version",
-    "pretest": "TZ=UTC node -e 'require(\"./test/db\").createdb()'",
+    "pretest": "node -e 'require(\"./test/db\").createdb()'",
     "test": "TZ=UTC tap test/*-test.js",
     "posttest": "standard",
     "test-cov": "TZ=UTC tap --cov test/*-test.js"

--- a/test/annotation-test.js
+++ b/test/annotation-test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const { beforeEach, afterEach, teardown, test } = require('tap')
+const {beforeEach, afterEach, teardown, test} = require('tap')
 
 const db = require('./db')
-const { Invoice, LineItem } = require('./models')
+const {Invoice, LineItem} = require('./models')
 
 db.setup(beforeEach, afterEach, teardown)
 
@@ -66,12 +66,13 @@ test('annotate, group, refstar', assert => {
   return Invoice.objects.all().group().annotate({
     lineItems: ref => `json_agg(${ref('line_items.*')})`
   }).order('id').then(results => {
-    assert.deepEqual(results.map(xs => {
-      return [xs[0].id, xs[1].lineItems.map(ys => ys.invoice_id)]
-    }), [
-      [1, Array.from(Array(10)).map(xs => 1)],
-      [2, Array.from(Array(10)).map(xs => 2)],
-      [3, Array.from(Array(10)).map(xs => 3)]
-    ])
+    assert.deepEqual(results.map(
+      xs => [xs[0].id, xs[1].lineItems.map(ys => ys.invoice_id)]),
+      [
+        [1, Array.from(Array(10)).map(xs => 1)],
+        [2, Array.from(Array(10)).map(xs => 2)],
+        [3, Array.from(Array(10)).map(xs => 3)]
+      ]
+    )
   })
 })

--- a/test/annotation-test.js
+++ b/test/annotation-test.js
@@ -1,85 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { beforeEach, afterEach, teardown, test } = require('tap')
 
-const orm = require('..')
-const db = require('./db.js')
+const db = require('./db')
+const { Invoice, LineItem } = require('./models')
 
-class Invoice {
-  constructor (obj) {
-    this.id = obj.id
-    this.name = obj.name
-    this.date = obj.date
-  }
-}
-
-Invoice.objects = orm(Invoice, {
-  id: orm.joi.number().required(),
-  name: orm.joi.string(),
-  date: orm.joi.date()
-})
-
-class LineItem {
-  constructor (obj) {
-    this.id = obj.id
-    this.subtotal = obj.subtotal
-    this.discount = obj.discount
-    this.invoice_id = obj.invoice_id
-    this.invoice = obj.invoice
-  }
-}
-
-LineItem.objects = orm(LineItem, {
-  id: orm.joi.number().required(),
-  invoice: orm.fk(Invoice),
-  subtotal: orm.joi.number(),
-  discount: orm.joi.number()
-})
-
-test('setup database', function (assert) {
-  db.setup().then(assert.end, assert.end)
-})
-
-test('create schema', function (assert) {
-  const invoices = db.schema`
-    CREATE TABLE invoices (
-      id serial primary key,
-      name varchar(255),
-      date timestamp
-    );
-  `
-  const lineitems = invoices.then(_ => db.schema`
-    CREATE TABLE line_items (
-      id serial primary key,
-      subtotal real,
-      discount real,
-      invoice_id integer default null references "invoices" ("id") on delete cascade
-    );
-  `)
-
-  return lineitems
-})
-
-test('create some invoices and line items', assert => {
-  return Invoice.objects.create([{
-    name: 'a thing',
-    date: Date.UTC(2012, 0, 1)
-  }, {
-    name: 'another thing',
-    date: Date.UTC(2013, 9, 19)
-  }, {
-    name: 'great',
-    date: Date.UTC(2016, 10, 20)
-  }]).then().map(invoice => {
-    return LineItem.objects.create(Array.from(Array(10)).map((_, idx) => {
-      return {
-        invoice,
-        subtotal: 10 * (idx + 1),
-        discount: idx
-      }
-    }))
-  })
-})
+db.setup(beforeEach, afterEach, teardown)
 
 test('non-grouped annotation', assert => {
   return LineItem.objects.all().annotate({
@@ -148,8 +74,4 @@ test('annotate, group, refstar', assert => {
       [3, Array.from(Array(10)).map(xs => 3)]
     ])
   })
-})
-
-test('drop database', function (assert) {
-  db.teardown().then(assert.end, assert.end)
 })

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { beforeEach, afterEach, teardown, test } = require('tap')
+const {beforeEach, afterEach, teardown, test} = require('tap')
 
 const ormnomnom = require('..')
 const db = require('./db')
@@ -13,12 +13,9 @@ test('produces expected table name', assert => {
   const objects = ormnomnom(TestFoo, {
     id: ormnomnom.joi.number()
   })
-  objects.all().sql.then(sql => {
+  return objects.all().sql.then(sql => {
     assert.ok(/"test_foos"/g.test(sql))
   })
-  .return(null)
-  .then(assert.end)
-  .catch(assert.end)
 })
 
 test('throws if passed to two ormnomnoms', assert => {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -7,7 +7,7 @@ const db = require('./db')
 
 db.setup(beforeEach, afterEach, teardown)
 
-test('produces expected table name', function (assert) {
+test('produces expected table name', assert => {
   class TestFoo {
   }
   const objects = ormnomnom(TestFoo, {
@@ -21,7 +21,7 @@ test('produces expected table name', function (assert) {
   .catch(assert.end)
 })
 
-test('throws if passed to two ormnomnoms', function (assert) {
+test('throws if passed to two ormnomnoms', assert => {
   class TestFoo {
   }
   ormnomnom(TestFoo, {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { beforeEach, afterEach, teardown, test } = require('tap')
 
 const ormnomnom = require('..')
 const db = require('./db.js')
 
-test('setup database', function (assert) {
-  db.setup().then(assert.end, assert.end)
-})
+db.setup(beforeEach, afterEach, teardown)
 
 test('produces expected table name', function (assert) {
   class TestFoo {
@@ -35,8 +33,4 @@ test('throws if passed to two ormnomnoms', function (assert) {
   })
 
   assert.end()
-})
-
-test('drop database', function (assert) {
-  db.teardown().then(assert.end, assert.end)
 })

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -3,7 +3,7 @@
 const { beforeEach, afterEach, teardown, test } = require('tap')
 
 const ormnomnom = require('..')
-const db = require('./db.js')
+const db = require('./db')
 
 db.setup(beforeEach, afterEach, teardown)
 

--- a/test/db.js
+++ b/test/db.js
@@ -3,13 +3,13 @@
 module.exports = {
   createdb: createdb,
   setup: setup,
-  schema: schema,
   getConnection: getConnection
 }
 
 const Promise = require('bluebird')
+const fs = require('fs')
 const ormnomnom = require('..')
-const models = require('./models')
+const path = require('path')
 const pg = require('pg')
 const pgtools = require('pgtools')
 
@@ -29,87 +29,9 @@ function createdb () {
   }).then(_ => {
     return pgtools.createdb({}, TEST_DB_NAME)
   }).then(_ => {
-    return schema`
-      CREATE TABLE invoices (
-        id serial primary key,
-        name varchar(255),
-        date timestamp
-      );
-
-      CREATE TABLE line_items (
-        id serial primary key,
-        subtotal real,
-        discount real,
-        invoice_id integer default null references "invoices" ("id") on delete cascade
-      );
-
-      CREATE TABLE nodes (
-        id serial primary key,
-        name varchar(255),
-        val real
-      );
-
-      CREATE TABLE refs (
-        id serial primary key,
-        node_id integer not null references "nodes" ("id") on delete cascade,
-        val real
-      );
-
-      CREATE TABLE farouts (
-        id serial primary key,
-        ref_id integer default null references "refs" ("id") on delete cascade
-      );
-    `
-  }).then(_ => {
-    return models.Invoice.objects.create([{
-      name: 'a thing',
-      date: Date.UTC(2012, 0, 1)
-    }, {
-      name: 'another thing',
-      date: Date.UTC(2013, 9, 19)
-    }, {
-      name: 'great',
-      date: Date.UTC(2016, 10, 20)
-    }]).then().map(invoice => {
-      return models.LineItem.objects.create(Array.from(Array(10)).map((_, idx) => {
-        return {
-          invoice,
-          subtotal: 10 * (idx + 1),
-          discount: idx
-        }
-      }))
+    return getConnection().then(client => {
+      return client.connection.query(fs.readFileSync(path.join(__dirname, 'fixture.sql'), { encoding: 'utf8' })).then(_ => client.connection.end())
     })
-  }).then(_ => {
-    return models.Node.objects.create([{
-      name: 'HELLO',
-      val: 3
-    }, {
-      name: 'Gary busey',
-      val: -10
-    }, {
-      name: 'John Bonham',
-      val: 10000
-    }, {
-      name: 'Mona Lisa',
-      val: 100
-    }])
-  }).then(_ => {
-    return models.Node.objects.create({
-      val: 10
-    })
-  }).then(_ => {
-    return models.Ref.objects.create([{
-      node_id: 1,
-      val: 10
-    }, {
-      node_id: 2,
-      val: 0
-    }, {
-      node_id: 3,
-      val: 0
-    }])
-  }).then(_ => {
-    return getConnection().then(client => client.connection.end())
   })
 }
 
@@ -154,19 +76,5 @@ function getConnection (commit) {
         release: _ => {}
       })
     })
-  })
-}
-
-function schema (chunks) {
-  chunks = chunks.slice()
-  const args = [].slice.call(arguments, 1)
-  const out = [chunks.shift()]
-  while (chunks.length) {
-    out.push(args.shift())
-    out.push(chunks.shift())
-  }
-  const ddl = out.join('')
-  return getConnection(true).then(function (client) {
-    return client.connection.query(ddl).then(_ => client.release())
   })
 }

--- a/test/db.js
+++ b/test/db.js
@@ -26,11 +26,11 @@ function createdb () {
     if (err.name !== 'invalid_catalog_name') {
       throw err
     }
-  }).then(_ => {
+  }).then(() => {
     return pgtools.createdb({}, TEST_DB_NAME)
-  }).then(_ => {
+  }).then(() => {
     return getConnection().then(client => {
-      return client.connection.query(fs.readFileSync(path.join(__dirname, 'fixture.sql'), { encoding: 'utf8' })).then(_ => client.connection.end())
+      return client.connection.query(fs.readFileSync(path.join(__dirname, 'fixture.sql'), {encoding: 'utf8'})).then(() => client.connection.end())
     })
   })
 }
@@ -62,18 +62,18 @@ function getConnection (commit) {
     if (connected) {
       return resolve({
         connection: client,
-        release: _ => {}
+        release: () => {}
       })
     }
 
     client.connect()
     client.once('error', reject)
-    client.once('connect', _ => {
+    client.once('connect', () => {
       client.removeListener('error', reject)
       connected = true
       resolve({
         connection: client,
-        release: _ => {}
+        release: () => {}
       })
     })
   })

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -4,7 +4,7 @@ const Promise = require('bluebird')
 const { beforeEach, afterEach, teardown, test } = require('tap')
 
 const ormnomnom = require('..')
-const db = require('./db.js')
+const db = require('./db')
 const { Node, Ref } = require('./models')
 
 db.setup(beforeEach, afterEach, teardown)

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const Promise = require('bluebird')
-const { beforeEach, afterEach, teardown, test } = require('tap')
+const {beforeEach, afterEach, teardown, test} = require('tap')
 
 const ormnomnom = require('..')
 const db = require('./db')
-const { Node, Ref } = require('./models')
+const {Node, Ref} = require('./models')
 
 db.setup(beforeEach, afterEach, teardown)
 
@@ -172,7 +172,7 @@ test('test invalid fk filter: not a model', assert => {
     'val': ormnomnom.joi.number().required()
   })
 
-  return RefObjects.filter({'node.id': 3}).then(_ => {
+  return RefObjects.filter({'node.id': 3}).then(() => {
     throw new Error('expected error')
   }, err => {
     assert.equal(err.message, 'No DAO registered for FakeNode')
@@ -180,7 +180,7 @@ test('test invalid fk filter: not a model', assert => {
 })
 
 test('test invalid fk filter: not a fk', assert => {
-  return Ref.objects.filter({'val.id': 3}).then(_ => {
+  return Ref.objects.filter({'val.id': 3}).then(() => {
     throw new Error('expected error')
   }, err => {
     assert.equal(err.message, 'val is not a join-able column')
@@ -268,7 +268,7 @@ test('test :in on empty array', assert => {
 })
 
 test('test chaining filters', assert => {
-  return Node.objects.filter({ id: 1 }).filter({ name: 'HELLO' }).then(xs => {
+  return Node.objects.filter({id: 1}).filter({name: 'HELLO'}).then(xs => {
     assert.deepEquals(xs, [{
       id: 1,
       name: 'HELLO',
@@ -278,7 +278,7 @@ test('test chaining filters', assert => {
 })
 
 test('test converts falsey filter to match all', assert => {
-  return Node.objects.filter([{ id: 1 }, null]).sql.then(xs => {
+  return Node.objects.filter([{id: 1}, null]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE ("nodes"."id" = $1 OR 1=1)')
   })
 })
@@ -314,7 +314,7 @@ test('test select with or with two empty objects', assert => {
 })
 
 test('test select with or with one filter and one empty object', assert => {
-  return Node.objects.filter([{ id: 1 }, {}]).sql.then(xs => {
+  return Node.objects.filter([{id: 1}, {}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE ("nodes"."id" = $1 OR 1=1)')
   })
 })
@@ -350,7 +350,7 @@ test('test select with or with two empty objects as exclude', assert => {
 })
 
 test('test select with or with one filter and one empty object as exclude', assert => {
-  return Node.objects.exclude([{ id: 1 }, {}]).sql.then(xs => {
+  return Node.objects.exclude([{id: 1}, {}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT ("nodes"."id" = $1 OR 1=1)')
   })
 })

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -146,16 +146,13 @@ const filterTests = [{
 
 for (const scenario of filterTests) {
   test('test of ' + JSON.stringify(scenario.query._filter), assert => {
-    scenario.query.valuesList('id').then(ids => {
+    return scenario.query.valuesList('id').then(ids => {
       assert.deepEqual(ids, scenario.expect)
     }, err => {
       return scenario.query.sql.then(sql => {
         throw new Error(sql + '\n' + err.message)
       })
     })
-    .return(null)
-    .then(assert.end)
-    .catch(assert.end)
   })
 }
 
@@ -175,25 +172,25 @@ test('test invalid fk filter: not a model', assert => {
     'val': ormnomnom.joi.number().required()
   })
 
-  RefObjects.filter({'node.id': 3}).then(_ => {
+  return RefObjects.filter({'node.id': 3}).then(_ => {
     throw new Error('expected error')
   }, err => {
     assert.equal(err.message, 'No DAO registered for FakeNode')
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test invalid fk filter: not a fk', assert => {
-  Ref.objects.filter({'val.id': 3}).then(_ => {
+  return Ref.objects.filter({'val.id': 3}).then(_ => {
     throw new Error('expected error')
   }, err => {
     assert.equal(err.message, 'val is not a join-able column')
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test order + count', assert => {
-  Node.objects.all().order('val').count().then(cnt => {
+  return Node.objects.all().order('val').count().then(cnt => {
     assert.ok('should have succeeded.')
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test filter by foreign instance', assert => {
@@ -201,9 +198,9 @@ test('test filter by foreign instance', assert => {
   const getRefs = getNode.then(node => {
     return Ref.objects.filter({node}).valuesList('id')
   })
-  getRefs.then(ids => {
+  return getRefs.then(ids => {
     assert.deepEqual(ids, [2])
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test filter by OR', assert => {
@@ -225,7 +222,7 @@ test('test filter by OR', assert => {
       'Gary busey',
       'Jake busey'
     ], raw.values)
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test filter by OR+promise', assert => {
@@ -247,16 +244,16 @@ test('test filter by OR+promise', assert => {
       'Gary busey',
       'Jake busey'
     ], raw.values)
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test filter by foreign promise', assert => {
   const getRefs = Ref.objects.filter({
     node: Node.objects.get({name: 'Gary busey'})
   }).valuesList('id')
-  getRefs.then(ids => {
+  return getRefs.then(ids => {
     assert.deepEqual(ids, [2])
-  }).return(null).then(assert.end).catch(assert.end)
+  })
 })
 
 test('test :in on empty array', assert => {

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -270,6 +270,16 @@ test('test :in on empty array', assert => {
   })
 })
 
+test('test chaining filters', assert => {
+  return Node.objects.filter({ id: 1 }).filter({ name: 'HELLO' }).then(xs => {
+    assert.deepEquals(xs, [{
+      id: 1,
+      name: 'HELLO',
+      val: 3
+    }])
+  })
+})
+
 test('test select with empty condition', assert => {
   return Node.objects.filter().sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"')

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -280,6 +280,12 @@ test('test chaining filters', assert => {
   })
 })
 
+test('test converts falsey filter to match all', assert => {
+  return Node.objects.filter([{ id: 1 }, null]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE ("nodes"."id" = $1 OR 1=1)')
+  })
+})
+
 test('test select with empty condition', assert => {
   return Node.objects.filter().sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"')

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -1,211 +1,146 @@
 'use strict'
 
 const Promise = require('bluebird')
-const test = require('tap').test
+const { beforeEach, afterEach, teardown, test } = require('tap')
 
 const ormnomnom = require('..')
 const db = require('./db.js')
+const { Node, Ref } = require('./models')
 
-class Frobnicator {
-  constructor (props) {
-    Object.assign(this, props)
-  }
-}
-
-class Ref {
-  constructor (props) {
-    Object.assign(this, props)
-  }
-}
-
-const FrobnicatorObjects = ormnomnom(Frobnicator, {
-  'id': ormnomnom.joi.number(),
-  'name': ormnomnom.joi.string(),
-  'val': ormnomnom.joi.number().required()
-})
-
-const RefObjects = ormnomnom(Ref, {
-  'id': ormnomnom.joi.number().required(),
-  'frob': ormnomnom.fk(Frobnicator),
-  'val': ormnomnom.joi.number().required()
-})
-
-const testData = [
-  {kind: FrobnicatorObjects, name: 'HELLO', val: 3},
-  {kind: FrobnicatorObjects, name: 'Gary busey', val: -10},
-  {kind: FrobnicatorObjects, name: 'John Bonham', val: 10000},
-  {kind: FrobnicatorObjects, name: 'Mona Lisa', val: 10},
-  {kind: FrobnicatorObjects, val: 10},
-  {kind: RefObjects, frob_id: 1, val: 10},
-  {kind: RefObjects, frob_id: 2, val: 0},
-  {kind: RefObjects, frob_id: 3, val: 0}
-]
-
-test('setup database', function (assert) {
-  db.setup().then(assert.end, assert.end)
-})
-
-test('create schema', function (assert) {
-  const frobs = db.schema`
-    CREATE TABLE frobnicators (
-      id serial primary key,
-      name varchar(255),
-      val real
-    );
-  `
-  const refs = frobs.then(_ => db.schema`
-    CREATE TABLE refs (
-      id serial primary key,
-      frob_id integer not null references "frobnicators" ("id") on delete cascade,
-      val real
-    );
-  `)
-  const data = refs.then(_ => {
-    return testData.reduce((seq, xs) => {
-      return seq.then(_ => {
-        return xs.kind.create(xs)
-      })
-    }, Promise.resolve(null))
-  })
-
-  data
-    .return(null)
-    .then(assert.end)
-    .catch(assert.end)
-})
+db.setup(beforeEach, afterEach, teardown)
 
 const filterTests = [{
-  query: FrobnicatorObjects.all(),
+  query: Node.objects.all(),
   expect: [1, 2, 3, 4, 5]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:eq': 'HELLO'
   }),
   expect: [1]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:eq': 'hello'
   }),
   expect: []
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:neq': 'HELLO'
   }),
   expect: [2, 3, 4]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:raw' (column, push) {
       return `char_length(${column}) = $${push(11)}`
     }
   }),
   expect: [3]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:contains': 'on'
   }),
   expect: [3, 4]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:startsWith': 'Gary'
   }),
   expect: [2]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:endsWith': 'busey'
   }),
   expect: [2]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:in': ['Gary busey', 'Mona Lisa', 'HELLO']
   }),
   expect: [1, 2, 4]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:in': []
   }),
   expect: []
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:notIn': ['Gary busey']
   }),
   expect: [1, 3, 4]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:notIn': []
   }),
   expect: [1, 2, 3, 4, 5]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:isNull': true
   }),
   expect: [5]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:isNull': false
   }),
   expect: [1, 2, 3, 4]
 }, {
-  query: RefObjects.filter([{
-    'frob.name': 'HELLO'
+  query: Ref.objects.filter([{
+    'node.name': 'HELLO'
   }, {
     'val': 0
   }]),
   expect: [1, 2, 3]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'val:lt': 3
   }),
   expect: [2]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'val:lte': 5
   }),
   expect: [1, 2]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'val:gt': 10
   }),
-  expect: [3]
+  expect: [3, 4]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'val:gte': 10
   }),
   expect: [3, 4, 5]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:iStartsWith': 'm'
   }),
   expect: [4]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:iEndsWith': 'o'
   }),
   expect: [1]
 }, {
-  query: FrobnicatorObjects.filter({
+  query: Node.objects.filter({
     'name:iContains': 'o'
   }),
   expect: [1, 3, 4]
 }, {
-  query: RefObjects.filter({
-    'frob.name:contains': 'o',
-    'frob.val:gt': 10
+  query: Ref.objects.filter({
+    'node.name:contains': 'o',
+    'node.val:gt': 10
   }),
   expect: [3]
 }, {
-  query: RefObjects.all().order('-frob.name'),
+  query: Ref.objects.all().order('-node.name'),
   expect: [3, 1, 2]
 }, {
-  query: RefObjects.all().order('frob.val'),
+  query: Ref.objects.all().order('node.val'),
   expect: [2, 1, 3]
 }, {
-  query: FrobnicatorObjects.all().order('val'),
-  expect: [2, 1, 4, 5, 3]
-}, {
-  query: FrobnicatorObjects.all().order(['val', '-id']),
+  query: Node.objects.all().order('val'),
   expect: [2, 1, 5, 4, 3]
 }, {
-  query: FrobnicatorObjects.exclude({'name:iContains': 'o'}),
+  query: Node.objects.all().order(['val', '-id']),
+  expect: [2, 1, 5, 4, 3]
+}, {
+  query: Node.objects.exclude({'name:iContains': 'o'}),
   expect: [2]
 }]
 
@@ -231,24 +166,24 @@ test('test invalid fk filter: not a model', function (assert) {
     }
   }
 
-  class FakeFrob {
+  class FakeNode {
   }
 
   const RefObjects = ormnomnom(Ref, {
     'id': ormnomnom.joi.number(),
-    'frob': ormnomnom.fk(FakeFrob),
+    'node': ormnomnom.fk(FakeNode),
     'val': ormnomnom.joi.number().required()
   })
 
-  RefObjects.filter({'frob.id': 3}).then(_ => {
+  RefObjects.filter({'node.id': 3}).then(_ => {
     throw new Error('expected error')
   }, err => {
-    assert.equal(err.message, 'No DAO registered for FakeFrob')
+    assert.equal(err.message, 'No DAO registered for FakeNode')
   }).return(null).then(assert.end).catch(assert.end)
 })
 
 test('test invalid fk filter: not a fk', function (assert) {
-  RefObjects.filter({'val.id': 3}).then(_ => {
+  Ref.objects.filter({'val.id': 3}).then(_ => {
     throw new Error('expected error')
   }, err => {
     assert.equal(err.message, 'val is not a join-able column')
@@ -256,15 +191,15 @@ test('test invalid fk filter: not a fk', function (assert) {
 })
 
 test('test order + count', function (assert) {
-  FrobnicatorObjects.all().order('val').count().then(cnt => {
+  Node.objects.all().order('val').count().then(cnt => {
     assert.ok('should have succeeded.')
   }).return(null).then(assert.end).catch(assert.end)
 })
 
 test('test filter by foreign instance', function (assert) {
-  var getFrob = FrobnicatorObjects.get({name: 'Gary busey'})
-  var getRefs = getFrob.then(frob => {
-    return RefObjects.filter({frob}).valuesList('id')
+  var getNode = Node.objects.get({name: 'Gary busey'})
+  var getRefs = getNode.then(node => {
+    return Ref.objects.filter({node}).valuesList('id')
   })
   getRefs.then(ids => {
     assert.deepEqual(ids, [2])
@@ -272,7 +207,7 @@ test('test filter by foreign instance', function (assert) {
 })
 
 test('test filter by OR', function (assert) {
-  var getSQL = FrobnicatorObjects.filter([{
+  var getSQL = Node.objects.filter([{
     name: 'Gary busey'
   }, {
     name: 'Jake busey'
@@ -282,7 +217,7 @@ test('test filter by OR', function (assert) {
     raw.release()
     assert.ok(
       raw.sql.indexOf(
-        'WHERE ("frobnicators"."name" = $1 OR "frobnicators"."name" = $2)'
+        'WHERE ("nodes"."name" = $1 OR "nodes"."name" = $2)'
       ) !== -1,
       'contains expected clause'
     )
@@ -294,7 +229,7 @@ test('test filter by OR', function (assert) {
 })
 
 test('test filter by OR+promise', function (assert) {
-  var getSQL = FrobnicatorObjects.filter([{
+  var getSQL = Node.objects.filter([{
     name: Promise.resolve('Gary busey')
   }, {
     name: Promise.resolve('Jake busey')
@@ -304,7 +239,7 @@ test('test filter by OR+promise', function (assert) {
     raw.release()
     assert.ok(
       raw.sql.indexOf(
-        'WHERE ("frobnicators"."name" = $1 OR "frobnicators"."name" = $2)'
+        'WHERE ("nodes"."name" = $1 OR "nodes"."name" = $2)'
       ) !== -1,
       'contains expected clause'
     )
@@ -316,8 +251,8 @@ test('test filter by OR+promise', function (assert) {
 })
 
 test('test filter by foreign promise', function (assert) {
-  var getRefs = RefObjects.filter({
-    frob: FrobnicatorObjects.get({name: 'Gary busey'})
+  var getRefs = Ref.objects.filter({
+    node: Node.objects.get({name: 'Gary busey'})
   }).valuesList('id')
   getRefs.then(ids => {
     assert.deepEqual(ids, [2])
@@ -325,7 +260,7 @@ test('test filter by foreign promise', function (assert) {
 })
 
 test('test :in on empty array', assert => {
-  const getRefs = RefObjects.filter({
+  const getRefs = Ref.objects.filter({
     'id:in': []
   })
 
@@ -333,8 +268,4 @@ test('test :in on empty array', assert => {
     assert.fail('did not expect err')
     assert.fail(err)
   })
-})
-
-test('drop database', function (assert) {
-  db.teardown().then(assert.end, assert.end)
 })

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -144,7 +144,7 @@ const filterTests = [{
   expect: [2]
 }]
 
-filterTests.forEach(scenario => {
+for (const scenario of filterTests) {
   test('test of ' + JSON.stringify(scenario.query._filter), assert => {
     scenario.query.valuesList('id').then(ids => {
       assert.deepEqual(ids, scenario.expect)
@@ -157,7 +157,7 @@ filterTests.forEach(scenario => {
     .then(assert.end)
     .catch(assert.end)
   })
-})
+}
 
 test('test invalid fk filter: not a model', function (assert) {
   class Ref {

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -269,3 +269,75 @@ test('test :in on empty array', assert => {
     assert.fail(err)
   })
 })
+
+test('test select with empty condition', function (assert) {
+  return Node.objects.filter().sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"')
+  })
+})
+
+test('test select with empty object as filter', function (assert) {
+  return Node.objects.filter({}).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE 1=1')
+  })
+})
+
+test('test select with empty or', function (assert) {
+  return Node.objects.filter([]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE 1=1')
+  })
+})
+
+test('test select with or with single empty object', function (assert) {
+  return Node.objects.filter([{}]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE 1=1')
+  })
+})
+
+test('test select with or with two empty objects', function (assert) {
+  return Node.objects.filter([{}, {}]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE (1=1 OR 1=1)')
+  })
+})
+
+test('test select with or with one filter and one empty object', function (assert) {
+  return Node.objects.filter([{ id: 1 }, {}]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE ("nodes"."id" = $1 OR 1=1)')
+  })
+})
+
+test('test select with empty exclude', function (assert) {
+  return Node.objects.exclude().sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"')
+  })
+})
+
+test('test select with empty object as exclude', function (assert) {
+  return Node.objects.exclude({}).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT 1=1')
+  })
+})
+
+test('test select with empty or as exclude', function (assert) {
+  return Node.objects.exclude([]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT 1=1')
+  })
+})
+
+test('test select with or with single empty object as exclude', function (assert) {
+  return Node.objects.exclude([{}]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT 1=1')
+  })
+})
+
+test('test select with or with two empty objects as exclude', function (assert) {
+  return Node.objects.exclude([{}, {}]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT (1=1 OR 1=1)')
+  })
+})
+
+test('test select with or with one filter and one empty object as exclude', function (assert) {
+  return Node.objects.exclude([{ id: 1 }, {}]).sql.then(xs => {
+    assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT ("nodes"."id" = $1 OR 1=1)')
+  })
+})

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -197,8 +197,8 @@ test('test order + count', function (assert) {
 })
 
 test('test filter by foreign instance', function (assert) {
-  var getNode = Node.objects.get({name: 'Gary busey'})
-  var getRefs = getNode.then(node => {
+  const getNode = Node.objects.get({name: 'Gary busey'})
+  const getRefs = getNode.then(node => {
     return Ref.objects.filter({node}).valuesList('id')
   })
   getRefs.then(ids => {
@@ -207,7 +207,7 @@ test('test filter by foreign instance', function (assert) {
 })
 
 test('test filter by OR', function (assert) {
-  var getSQL = Node.objects.filter([{
+  const getSQL = Node.objects.filter([{
     name: 'Gary busey'
   }, {
     name: 'Jake busey'
@@ -229,7 +229,7 @@ test('test filter by OR', function (assert) {
 })
 
 test('test filter by OR+promise', function (assert) {
-  var getSQL = Node.objects.filter([{
+  const getSQL = Node.objects.filter([{
     name: Promise.resolve('Gary busey')
   }, {
     name: Promise.resolve('Jake busey')
@@ -251,7 +251,7 @@ test('test filter by OR+promise', function (assert) {
 })
 
 test('test filter by foreign promise', function (assert) {
-  var getRefs = Ref.objects.filter({
+  const getRefs = Ref.objects.filter({
     node: Node.objects.get({name: 'Gary busey'})
   }).valuesList('id')
   getRefs.then(ids => {

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -159,7 +159,7 @@ for (const scenario of filterTests) {
   })
 }
 
-test('test invalid fk filter: not a model', function (assert) {
+test('test invalid fk filter: not a model', assert => {
   class Ref {
     constructor (props) {
       Object.assign(this, props)
@@ -182,7 +182,7 @@ test('test invalid fk filter: not a model', function (assert) {
   }).return(null).then(assert.end).catch(assert.end)
 })
 
-test('test invalid fk filter: not a fk', function (assert) {
+test('test invalid fk filter: not a fk', assert => {
   Ref.objects.filter({'val.id': 3}).then(_ => {
     throw new Error('expected error')
   }, err => {
@@ -190,13 +190,13 @@ test('test invalid fk filter: not a fk', function (assert) {
   }).return(null).then(assert.end).catch(assert.end)
 })
 
-test('test order + count', function (assert) {
+test('test order + count', assert => {
   Node.objects.all().order('val').count().then(cnt => {
     assert.ok('should have succeeded.')
   }).return(null).then(assert.end).catch(assert.end)
 })
 
-test('test filter by foreign instance', function (assert) {
+test('test filter by foreign instance', assert => {
   const getNode = Node.objects.get({name: 'Gary busey'})
   const getRefs = getNode.then(node => {
     return Ref.objects.filter({node}).valuesList('id')
@@ -206,7 +206,7 @@ test('test filter by foreign instance', function (assert) {
   }).return(null).then(assert.end).catch(assert.end)
 })
 
-test('test filter by OR', function (assert) {
+test('test filter by OR', assert => {
   const getSQL = Node.objects.filter([{
     name: 'Gary busey'
   }, {
@@ -228,7 +228,7 @@ test('test filter by OR', function (assert) {
   }).return(null).then(assert.end).catch(assert.end)
 })
 
-test('test filter by OR+promise', function (assert) {
+test('test filter by OR+promise', assert => {
   const getSQL = Node.objects.filter([{
     name: Promise.resolve('Gary busey')
   }, {
@@ -250,7 +250,7 @@ test('test filter by OR+promise', function (assert) {
   }).return(null).then(assert.end).catch(assert.end)
 })
 
-test('test filter by foreign promise', function (assert) {
+test('test filter by foreign promise', assert => {
   const getRefs = Ref.objects.filter({
     node: Node.objects.get({name: 'Gary busey'})
   }).valuesList('id')
@@ -270,73 +270,73 @@ test('test :in on empty array', assert => {
   })
 })
 
-test('test select with empty condition', function (assert) {
+test('test select with empty condition', assert => {
   return Node.objects.filter().sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"')
   })
 })
 
-test('test select with empty object as filter', function (assert) {
+test('test select with empty object as filter', assert => {
   return Node.objects.filter({}).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE 1=1')
   })
 })
 
-test('test select with empty or', function (assert) {
+test('test select with empty or', assert => {
   return Node.objects.filter([]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE 1=1')
   })
 })
 
-test('test select with or with single empty object', function (assert) {
+test('test select with or with single empty object', assert => {
   return Node.objects.filter([{}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE 1=1')
   })
 })
 
-test('test select with or with two empty objects', function (assert) {
+test('test select with or with two empty objects', assert => {
   return Node.objects.filter([{}, {}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE (1=1 OR 1=1)')
   })
 })
 
-test('test select with or with one filter and one empty object', function (assert) {
+test('test select with or with one filter and one empty object', assert => {
   return Node.objects.filter([{ id: 1 }, {}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE ("nodes"."id" = $1 OR 1=1)')
   })
 })
 
-test('test select with empty exclude', function (assert) {
+test('test select with empty exclude', assert => {
   return Node.objects.exclude().sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"')
   })
 })
 
-test('test select with empty object as exclude', function (assert) {
+test('test select with empty object as exclude', assert => {
   return Node.objects.exclude({}).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT 1=1')
   })
 })
 
-test('test select with empty or as exclude', function (assert) {
+test('test select with empty or as exclude', assert => {
   return Node.objects.exclude([]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT 1=1')
   })
 })
 
-test('test select with or with single empty object as exclude', function (assert) {
+test('test select with or with single empty object as exclude', assert => {
   return Node.objects.exclude([{}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT 1=1')
   })
 })
 
-test('test select with or with two empty objects as exclude', function (assert) {
+test('test select with or with two empty objects as exclude', assert => {
   return Node.objects.exclude([{}, {}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT (1=1 OR 1=1)')
   })
 })
 
-test('test select with or with one filter and one empty object as exclude', function (assert) {
+test('test select with or with one filter and one empty object as exclude', assert => {
   return Node.objects.exclude([{ id: 1 }, {}]).sql.then(xs => {
     assert.equals(xs, 'SELECT "nodes"."id" AS "nodes.id", "nodes"."name" AS "nodes.name", "nodes"."val" AS "nodes.val" FROM "nodes" "nodes"  WHERE NOT ("nodes"."id" = $1 OR 1=1)')
   })

--- a/test/fixture.sql
+++ b/test/fixture.sql
@@ -87,5 +87,6 @@ INSERT INTO refs (node_id, val) VALUES
 
 CREATE TABLE farouts (
   id serial primary key,
-  ref_id integer default null references "refs" ("id") on delete cascade
+  ref_id integer default null references "refs" ("id") on delete cascade,
+  second_ref_id integer default null references "refs" ("id") on delete cascade
 );

--- a/test/fixture.sql
+++ b/test/fixture.sql
@@ -1,0 +1,91 @@
+CREATE TABLE invoices (
+  id serial primary key,
+  name varchar(255),
+  date timestamp
+);
+
+INSERT INTO invoices (name, date) VALUES
+    ('a thing', to_timestamp('1/1/2012', 'MM/DD/YYYY') AT TIME ZONE 'UTC'),
+    ('another thing', to_timestamp('10/19/2013', 'MM/DD/YYYY') AT TIME ZONE 'UTC'),
+    ('great', to_timestamp('11/20/2016', 'MM/DD/YYYY') AT TIME ZONE 'UTC');
+
+CREATE TABLE line_items (
+  id serial primary key,
+  subtotal real,
+  discount real,
+  invoice_id integer default null references "invoices" ("id") on delete cascade
+);
+
+WITH invoice AS (
+  SELECT id FROM invoices WHERE name = 'a thing'
+)
+INSERT INTO line_items (subtotal, discount, invoice_id) VALUES
+    (10, 0, (SELECT id FROM invoice)),
+    (20, 1, (SELECT id FROM invoice)),
+    (30, 2, (SELECT id FROM invoice)),
+    (40, 3, (SELECT id FROM invoice)),
+    (50, 4, (SELECT id FROM invoice)),
+    (60, 5, (SELECT id FROM invoice)),
+    (70, 6, (SELECT id FROM invoice)),
+    (80, 7, (SELECT id FROM invoice)),
+    (90, 8, (SELECT id FROM invoice)),
+    (100, 9, (SELECT id FROM invoice));
+
+WITH invoice AS (
+  SELECT id FROM invoices WHERE name = 'another thing'
+)
+INSERT INTO line_items (subtotal, discount, invoice_id) VALUES
+    (10, 0, (SELECT id FROM invoice)),
+    (20, 1, (SELECT id FROM invoice)),
+    (30, 2, (SELECT id FROM invoice)),
+    (40, 3, (SELECT id FROM invoice)),
+    (50, 4, (SELECT id FROM invoice)),
+    (60, 5, (SELECT id FROM invoice)),
+    (70, 6, (SELECT id FROM invoice)),
+    (80, 7, (SELECT id FROM invoice)),
+    (90, 8, (SELECT id FROM invoice)),
+    (100, 9, (SELECT id FROM invoice));
+
+WITH invoice AS (
+  SELECT id FROM invoices WHERE name = 'great'
+)
+INSERT INTO line_items (subtotal, discount, invoice_id) VALUES
+    (10, 0, (SELECT id FROM invoice)),
+    (20, 1, (SELECT id FROM invoice)),
+    (30, 2, (SELECT id FROM invoice)),
+    (40, 3, (SELECT id FROM invoice)),
+    (50, 4, (SELECT id FROM invoice)),
+    (60, 5, (SELECT id FROM invoice)),
+    (70, 6, (SELECT id FROM invoice)),
+    (80, 7, (SELECT id FROM invoice)),
+    (90, 8, (SELECT id FROM invoice)),
+    (100, 9, (SELECT id FROM invoice));
+
+CREATE TABLE nodes (
+  id serial primary key,
+  name varchar(255),
+  val real
+);
+
+INSERT INTO nodes (name, val) VALUES
+    ('HELLO', 3),
+    ('Gary busey', -10),
+    ('John Bonham', 10000),
+    ('Mona Lisa', 100),
+    (NULL, 10);
+
+CREATE TABLE refs (
+  id serial primary key,
+  node_id integer not null references "nodes" ("id") on delete cascade,
+  val real
+);
+
+INSERT INTO refs (node_id, val) VALUES
+    ((SELECT id FROM nodes WHERE name = 'HELLO'), 10),
+    ((SELECT id FROM nodes WHERE name = 'Gary busey'), 0),
+    ((SELECT id FROM nodes WHERE name = 'John Bonham'), 0);
+
+CREATE TABLE farouts (
+  id serial primary key,
+  ref_id integer default null references "refs" ("id") on delete cascade
+);

--- a/test/models.js
+++ b/test/models.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const orm = require('..')
+
+class Invoice {
+  constructor (obj) {
+    this.id = obj.id
+    this.name = obj.name
+    this.date = obj.date
+  }
+}
+
+Invoice.objects = orm(Invoice, {
+  id: orm.joi.number().required(),
+  name: orm.joi.string(),
+  date: orm.joi.date()
+})
+
+class LineItem {
+  constructor (obj) {
+    this.id = obj.id
+    this.subtotal = obj.subtotal
+    this.discount = obj.discount
+    this.invoice_id = obj.invoice_id
+    this.invoice = obj.invoice
+  }
+}
+
+LineItem.objects = orm(LineItem, {
+  id: orm.joi.number().required(),
+  invoice: orm.fk(Invoice),
+  subtotal: orm.joi.number(),
+  discount: orm.joi.number()
+})
+
+class Node {
+  constructor (obj) {
+    this.id = obj.id
+    this.name = obj.name
+    this.val = obj.val
+  }
+}
+
+Node.objects = orm(Node, {
+  id: orm.joi.number(),
+  name: orm.joi.string(),
+  val: orm.joi.number().required()
+})
+
+class Ref {
+  constructor (obj) {
+    this.id = obj.id
+    this.node = obj.node
+    this.node_id = obj.node_id
+    this.val = obj.val
+  }
+}
+
+Ref.objects = orm(Ref, {
+  id: orm.joi.number().required(),
+  node: orm.fk(Node),
+  val: orm.joi.number().required()
+})
+
+class Farout {
+  constructor (obj) {
+    this.id = obj.id
+    this.ref = obj.ref
+    this.ref_id = obj.ref_id
+  }
+}
+
+Farout.objects = orm(Farout, {
+  id: orm.joi.number(),
+  ref: orm.fk(Ref, { nullable: true })
+})
+
+module.exports = {
+  Invoice,
+  LineItem,
+  Node,
+  Ref,
+  Farout
+}

--- a/test/models.js
+++ b/test/models.js
@@ -67,12 +67,15 @@ class Farout {
     this.id = obj.id
     this.ref = obj.ref
     this.ref_id = obj.ref_id
+    this.second_ref = obj.second_ref
+    this.second_ref_id = obj.second_ref_id
   }
 }
 
 Farout.objects = orm(Farout, {
   id: orm.joi.number(),
-  ref: orm.fk(Ref, { nullable: true })
+  ref: orm.fk(Ref, {nullable: true}),
+  second_ref: orm.fk(Ref, {nullable: true})
 })
 
 module.exports = {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -1,125 +1,54 @@
 'use strict'
 
 const Promise = require('bluebird')
-const test = require('tap').test
+const { beforeEach, afterEach, teardown, test } = require('tap')
 
 const ormnomnom = require('..')
+const { Node, Ref, Farout } = require('./models')
 const db = require('./db.js')
 
-class Node {
-  constructor (props) {
-    this.id = props.id
-    this.name = props.name
-    this.val = props.val
-  }
-}
-class Ref {
-  constructor (props) {
-    this.id = props.id
-    this.node = props.node
-    this.node_id = props.node_id
-    this.val = props.val
-  }
-}
-class Farout {
-  constructor (props) {
-    this.id = props.id
-    this.ref = props.ref
-    this.ref_id = props.ref_id
-  }
-}
-
-const FaroutObjects = ormnomnom(Farout, {
-  id: ormnomnom.joi.number(),
-  ref: ormnomnom.fk(Ref, {nullable: true})
-})
-const RefObjects = ormnomnom(Ref, {
-  id: ormnomnom.joi.number(),
-  node: ormnomnom.fk(Node),
-  val: ormnomnom.joi.number()
-})
-var NodeObjects = ormnomnom(Node, {
-  id: ormnomnom.joi.number(),
-  name: ormnomnom.joi.string(),
-  val: ormnomnom.joi.number()
-})
-
-test('setup database', function (assert) {
-  db.setup().then(assert.end, assert.end)
-})
-
-test('create schema', function (assert) {
-  const nodes = db.schema`
-    CREATE TABLE nodes (
-      id serial primary key,
-      name varchar(255),
-      val real
-    );
-  `
-  const refs = nodes.then(_ => db.schema`
-    CREATE TABLE refs (
-      id serial primary key,
-      node_id integer not null references "nodes" ("id") on delete cascade,
-      val real
-    );
-  `)
-  const farouts = refs.then(_ => db.schema`
-    CREATE TABLE farouts (
-      id serial primary key,
-      ref_id integer default null references "refs" ("id") on delete cascade
-    );
-  `)
-  farouts
-    .return(null)
-    .then(assert.end)
-    .catch(assert.end)
-})
+db.setup(beforeEach, afterEach, teardown)
 
 test('test insert', assert => {
-  return NodeObjects.create({
+  return Node.objects.create({
     name: 'hello world',
     val: 3
   }).then(xs => {
     assert.ok(xs instanceof Node, 'xs is a Node')
-    assert.equal(xs.id, 1)
     assert.equal(xs.name, 'hello world')
     assert.equal(xs.val, 3)
-    return db.getConnection()
-  }).then(conn => {
-    return Promise.promisify(conn.connection.query.bind(conn.connection))(
-      'select * from nodes where id=1'
-    ).tap(() => conn.release())
-  }).then(results => {
-    assert.deepEqual(results.rows, [{
-      id: 1,
-      name: 'hello world',
-      val: 3
-    }], 'independently verify presence in db')
+    return db.getConnection().then(conn => {
+      return Promise.promisify(conn.connection.query.bind(conn.connection))(
+        `select * from nodes where id=${xs.id}`
+      ).tap(() => conn.release())
+    }).then(results => {
+      assert.deepEqual(results.rows, [{
+        id: xs.id,
+        name: 'hello world',
+        val: 3
+      }], 'independently verify presence in db')
+    })
   })
 })
 
 test('test update (none affected)', assert => {
-  return NodeObjects
-    .filter({'val:gt': 3})
-    .update({val: 10, name: 'gary busey'})
+  return Node.objects
+    .filter({'val:gt': 30000})
+    .update({val: 10, name: 'janis joplin'})
     .then(xs => {
       assert.equal(xs, 0)
       return db.getConnection()
     }).then(conn => {
       return Promise.promisify(conn.connection.query.bind(conn.connection))(
-        'select * from nodes'
+        'select * from nodes where name = \'janis joplin\''
       ).tap(() => conn.release())
     }).then(results => {
-      assert.deepEqual(results.rows, [{
-        id: 1,
-        name: 'hello world',
-        val: 3
-      }], 'independently verify presence in db')
+      assert.deepEqual(results.rows, [], 'independently verify presence in db')
     })
 })
 
 test('test update (one affected)', assert => {
-  return NodeObjects
+  return Node.objects
     .filter({'val': 3})
     .update({val: 10, name: 'gary busey'})
     .then(xs => {
@@ -127,7 +56,7 @@ test('test update (one affected)', assert => {
       return db.getConnection()
     }).then(conn => {
       return Promise.promisify(conn.connection.query.bind(conn.connection))(
-        'select * from nodes'
+        'select * from nodes where name = \'gary busey\''
       ).tap(() => conn.release())
     }).then(results => {
       assert.deepEqual(results.rows, [{
@@ -139,10 +68,10 @@ test('test update (one affected)', assert => {
 })
 
 test('test update (one affected, with join)', function (assert) {
-  return RefObjects.create({val: 0, node: NodeObjects.get({name: 'gary busey'})})
+  return Ref.objects.create({val: 0, node: Node.objects.get({name: 'Mona Lisa'})})
     .then(() => {
-      const subquery = RefObjects
-        .filter({'node.val': 10})
+      const subquery = Ref.objects
+        .filter({'node.val': 100})
         .update({val: 1000})
 
       return subquery
@@ -151,21 +80,36 @@ test('test update (one affected, with join)', function (assert) {
       return db.getConnection()
     }).then(conn => {
       return Promise.promisify(conn.connection.query.bind(conn.connection))(
-        'select * from refs'
+        'select * from refs where val=1000'
       ).tap(() => conn.release())
     }).then(results => {
       assert.deepEqual(results.rows, [{
-        id: 1,
-        node_id: 1,
+        id: 4,
+        node_id: 4,
         val: 1000
       }], 'independently verify presence in db')
     })
 })
 
-test('test delete', function (assert) {
-  return NodeObjects
-    .filter({ id: 1 })
+test('test filter with delete', function (assert) {
+  return Node.objects
+    .filter({ id: 1000 })
     .delete()
+    .then(xs => {
+      assert.deepEqual(xs, 0)
+      return db.getConnection()
+    }).then(conn => {
+      return Promise.promisify(conn.connection.query.bind(conn.connection))(
+        'select * from nodes'
+      ).tap(() => conn.release())
+    }).then(results => {
+      assert.deepEqual(results.rows.length, 5, 'verify all rows still exists')
+    })
+})
+
+test('test delete', function (assert) {
+  return Node.objects
+    .delete({ id: 1 })
     .then(xs => {
       assert.deepEqual(xs, 1)
       return db.getConnection()
@@ -174,14 +118,15 @@ test('test delete', function (assert) {
         'select * from nodes'
       ).tap(() => conn.release())
     }).then(results => {
-      assert.deepEqual(results.rows, [], 'independently verify absence in db')
+      assert.deepEqual(results.rows.length, 4, 'verify one row is removed')
+      assert.notOk(results.rows.find(row => row.id === 1), 'verify correct node is removed')
     })
 })
 
 test('test nested insert', function (assert) {
-  const createRef = RefObjects.create({
+  const createRef = Ref.objects.create({
     val: 10,
-    node: NodeObjects.create({
+    node: Node.objects.create({
       val: 100,
       name: 'jake busey'
     })
@@ -197,134 +142,130 @@ test('test nested insert', function (assert) {
 })
 
 test('test simple select', function (assert) {
-  return RefObjects.create({
+  return Ref.objects.create({
     val: 300,
-    node: NodeObjects.create({
-      name: 'gary busey',
+    node: Node.objects.create({
+      name: 'jake busey',
       val: -100
     })
   }).then(_ => {
-    return RefObjects.filter({'node.name:startsWith': 'jake'}).then(xs => {
+    return Ref.objects.filter({'node.name:startsWith': 'jake'}).then(xs => {
       assert.equal(xs.length, 1)
       assert.equal(xs[0].node.name, 'jake busey')
-      assert.equal(xs[0].val, 10)
+      assert.equal(xs[0].val, 300)
     })
   })
 })
 
 test('test values select', function (assert) {
-  return RefObjects.filter({'node.name:endsWith': 'busey'}).values('node_id').then(xs => {
+  return Ref.objects.filter({'node.name:endsWith': 'busey'}).values('node_id').then(xs => {
     assert.deepEqual(xs, [{
       node_id: 2
-    }, {
-      node_id: 3
     }])
     assert.ok(!(xs[0] instanceof Ref), 'should be plain objects')
   })
 })
 
 test('test deep values select', function (assert) {
-  return RefObjects.filter({'node.name:endsWith': 'busey'}).values(['node.name', 'node_id']).then(xs => {
+  return Ref.objects.filter({'node.name:endsWith': 'busey'}).values(['node.name', 'node_id']).then(xs => {
     assert.deepEqual(xs, [{
-      node: {name: 'jake busey'},
+      node: {name: 'Gary busey'},
       node_id: 2
-    }, {
-      node: {name: 'gary busey'},
-      node_id: 3
     }])
     assert.ok(!(xs[0] instanceof Ref), 'should be plain objects')
   })
 })
 
 test('test "in query" optimization', function (assert) {
-  return RefObjects.filter({
-    'node_id:in': NodeObjects.filter({name: 'gary busey'}).valuesList('id')
+  return Ref.objects.filter({
+    'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')
   }).sql.then(sql => {
     assert.equal(sql.replace(/\n\s+/gm, ' ').trim(), `SELECT "refs"."id" AS "refs.id", "refs"."node_id" AS "refs.node_id", "refs"."val" AS "refs.val" FROM "refs" "refs"  WHERE "refs"."node_id" IN (SELECT "nodes"."id" AS "nodes.id" FROM "nodes" "nodes"  WHERE "nodes"."name" = $1)`)
   })
 })
 
 test('test "in query" optimization w/prepended value', function (assert) {
-  return RefObjects.filter({
+  return Ref.objects.filter({
     'node.name': 'squidward',
-    'node_id:in': NodeObjects.filter({name: 'gary busey'}).valuesList('id')
+    'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')
   }).sql.then(sql => {
     assert.equal(sql.replace(/\n\s+/gm, ' ').trim(), `SELECT "refs"."id" AS "refs.id", "refs"."node_id" AS "refs.node_id", "refs"."val" AS "refs.val", "nodes"."id" AS "refs.node.id", "nodes"."name" AS "refs.node.name", "nodes"."val" AS "refs.node.val" FROM "refs" "refs" LEFT  JOIN "nodes" "nodes" ON ( "refs"."node_id" = "nodes"."id" ) WHERE ("nodes"."name" = $1 AND "refs"."node_id" IN (SELECT "nodes"."id" AS "nodes.id" FROM "nodes" "nodes"  WHERE "nodes"."name" = $2))`)
   })
 })
 
 test('test values list', function (assert) {
-  return RefObjects.filter({'node.name:endsWith': 'busey'}).valuesList(['node_id', 'node.val']).then(xs => {
-    assert.deepEqual(xs, [2, 100, 3, -100])
+  return Ref.objects.filter({'node.name:endsWith': 'busey'}).valuesList(['node_id', 'node.val']).then(xs => {
+    assert.deepEqual(xs, [2, -10])
   })
 })
 
 test('test count', function (assert) {
-  return NodeObjects.filter({'val:gt': 10}).count().then(function (xs) {
-    assert.equal(xs, '1')
+  return Node.objects.filter({'val:gt': 10}).count().then(function (xs) {
+    assert.equal(xs, '2')
   })
 })
 
 test('test getOrCreate already exists', function (assert) {
-  return NodeObjects.getOrCreate({name: 'jake busey', val: 100}).spread((created, xs) => {
+  return Node.objects.getOrCreate({name: 'Gary busey', val: -10}).spread((created, xs) => {
     assert.equal(created, false)
-    assert.equal(xs.name, 'jake busey')
+    assert.equal(xs.name, 'Gary busey')
   })
 })
 
 test('test getOrCreate does not exist', function (assert) {
-  return NodeObjects.getOrCreate({name: 'johnny five', val: 100}).spread((created, xs) => {
+  return Node.objects.getOrCreate({name: 'johnny five', val: 100}).spread((created, xs) => {
     assert.equal(created, true)
     assert.equal(xs.name, 'johnny five')
   })
 })
 
 test('test getOrCreate multiple objects returned', function (assert) {
-  var cloneBusey = NodeObjects.create({
-    name: 'jake busey',
+  var cloneBusey = Node.objects.create({
+    name: 'Gary busey',
     val: 0xdeadbeef
   })
 
-  return NodeObjects.getOrCreate({name: cloneBusey.get('name')}).then(_ => {
+  return Node.objects.getOrCreate({name: cloneBusey.get('name')}).then(_ => {
     throw new Error('should throw exception')
   }, err => {
-    assert.equal(err.constructor, NodeObjects.MultipleObjectsReturned)
+    assert.equal(err.constructor, Node.objects.MultipleObjectsReturned)
   })
 })
 
 test('test get fails on multiple objects returned', function (assert) {
-  return NodeObjects.get({'name:contains': 'busey'}).catch(err => {
-    assert.equal(err.constructor, NodeObjects.MultipleObjectsReturned)
+  return Node.objects.get({'name:contains': 'busey'}).catch(err => {
+    assert.equal(err.constructor, Node.objects.MultipleObjectsReturned)
     assert.equal(err.message, 'Multiple Node objects returned')
     assert.ok(err instanceof ormnomnom.MultipleObjectsReturned)
   })
 })
 
 test('test get fails on zero objects returned', function (assert) {
-  return NodeObjects.get({'name': 'ford prefect'})
-  .catch(NodeObjects.NotFound, err => {
+  return Node.objects.get({'name': 'ford prefect'})
+  .catch(Node.objects.NotFound, err => {
     assert.equal(err.message, 'Node not found')
     assert.ok(err instanceof ormnomnom.NotFound)
   })
 })
 
 test('test reverse relation', function (assert) {
-  return NodeObjects.refsSetFor(
-    NodeObjects.get({name: 'gary busey'})
+  return Node.objects.refsSetFor(
+    Node.objects.get({name: 'Gary busey'})
   ).then(xs => {
     assert.equal(xs.length, 1)
-    assert.equal(xs[0].val, 300)
+    assert.equal(xs[0].val, 0)
+    assert.equal(xs[0].node.val, -10)
   })
 })
 
 test('test reverse query', function (assert) {
-  return NodeObjects.filter({'refs.val:gt': 0}).then(xs => {
-    assert.equal(xs.length, 2)
+  return Node.objects.filter({'refs.val:gt': 0}).then(xs => {
+    assert.equal(xs.length, 1)
   })
 })
 
 test('test bulk insert', function (assert) {
-  const bulkInsert = NodeObjects.create([{
+  const bulkInsert = Node.objects.create([{
     val: 100,
     name: 'jake busey'
   }, {
@@ -342,12 +283,12 @@ test('test bulk insert', function (assert) {
 })
 
 test('test group (no column specified)', assert => {
-  const getNode = NodeObjects.create({
+  const getNode = Node.objects.create({
     val: 10,
     name: 'goof'
   })
 
-  const getRefs = RefObjects.create(Array.from(Array(10)).map((xs, idx) => {
+  const getRefs = Ref.objects.create(Array.from(Array(10)).map((xs, idx) => {
     return {
       node: getNode,
       val: idx
@@ -355,7 +296,7 @@ test('test group (no column specified)', assert => {
   }))
 
   return getRefs.then(refs => {
-    return NodeObjects.filter({
+    return Node.objects.filter({
       id: getNode.get('id'),
       'refs.id:isNull': false
     }).group().annotate({
@@ -371,7 +312,7 @@ test('test group (no column specified)', assert => {
 })
 
 test('test group (no column specified, nonvalues)', assert => {
-  const getNode = NodeObjects.create([{
+  const getNode = Node.objects.create([{
     val: 10,
     name: 'cat'
   }, {
@@ -379,7 +320,7 @@ test('test group (no column specified, nonvalues)', assert => {
     name: 'floof'
   }])
 
-  const getRefs = RefObjects.create(Array.from(Array(10)).map((xs, idx) => {
+  const getRefs = Ref.objects.create(Array.from(Array(10)).map((xs, idx) => {
     return {
       node: getNode.get(idx & 1),
       val: idx
@@ -387,7 +328,7 @@ test('test group (no column specified, nonvalues)', assert => {
   }))
 
   return getRefs.then(refs => {
-    return NodeObjects.filter({
+    return Node.objects.filter({
       'name:in': ['cat', 'floof'],
       'refs.id:isNull': false
     }).group().annotate({
@@ -401,31 +342,31 @@ test('test group (no column specified, nonvalues)', assert => {
     }).order('-howMuch')
   }).then(results => {
     assert.deepEqual(results, [
-      [{id: 10, name: 'floof', val: 66044}, {nerds: [1, 3, 5, 7, 9], howMuch: 25}],
-      [{id: 9, name: 'cat', val: 10}, {nerds: [0, 2, 4, 6, 8], howMuch: 20}]
+      [{id: 15, name: 'floof', val: 66044}, {nerds: [1, 3, 5, 7, 9], howMuch: 25}],
+      [{id: 14, name: 'cat', val: 10}, {nerds: [0, 2, 4, 6, 8], howMuch: 20}]
     ])
   })
 })
 
 test('join delete', assert => {
-  const getNode = NodeObjects.create({
+  const getNode = Node.objects.create({
     val: 10,
     name: 'troop'
   })
 
-  const getRefs = RefObjects.create(Array.from(Array(10)).map((xs, idx) => {
+  const getRefs = Ref.objects.create(Array.from(Array(10)).map((xs, idx) => {
     return {
       node: getNode,
       val: idx
     }
   })).then().map(xs => {
-    return FaroutObjects.create({ref: xs})
+    return Farout.objects.create({ref: xs})
   })
 
   return getRefs.then(() => {
-    return FaroutObjects.delete({'ref.node.name': 'troop'})
+    return Farout.objects.delete({'ref.node.name': 'troop'})
   }).then(() => {
-    return FaroutObjects.filter({'ref.node.name': 'troop'}).count()
+    return Farout.objects.filter({'ref.node.name': 'troop'}).count()
   }).then(result => {
     assert.equal(Number(result), 0)
   })
@@ -433,8 +374,8 @@ test('join delete', assert => {
 
 test('empty AND', assert => {
   return Promise.all([
-    NodeObjects.filter({}).order('id'),
-    NodeObjects.all().order('id')
+    Node.objects.filter({}).order('id'),
+    Node.objects.all().order('id')
   ]).spread((lhs, rhs) => {
     assert.deepEqual(lhs, rhs)
   })
@@ -442,27 +383,27 @@ test('empty AND', assert => {
 
 test('empty OR', assert => {
   return Promise.all([
-    NodeObjects.filter([]).order('id'),
-    NodeObjects.all().order('id')
+    Node.objects.filter([]).order('id'),
+    Node.objects.all().order('id')
   ]).spread((lhs, rhs) => {
     assert.deepEqual(lhs, rhs)
   })
 })
 
 test('empty bulk INSERT', assert => {
-  return NodeObjects.create([]).then(result => {
+  return Node.objects.create([]).then(result => {
     assert.deepEqual(result, [])
   })
 })
 
 test('create null fk', assert => {
-  return FaroutObjects.create({ref: null}).then(result => {
+  return Farout.objects.create({ref: null}).then(result => {
     assert.equal(result.ref_id, null)
   })
 })
 
 test('join over non-fk', assert => {
-  return NodeObjects.filter({'val.foo': 3}).then(() => {
+  return Node.objects.filter({'val.foo': 3}).then(() => {
     throw new Error('unexpected')
   }, err => {
     assert.ok(/val/.test(err.message))
@@ -470,7 +411,7 @@ test('join over non-fk', assert => {
 })
 
 test('filter bad column', assert => {
-  return NodeObjects.filter({'dne': 3}).then(() => {
+  return Node.objects.filter({'dne': 3}).then(() => {
     throw new Error('unexpected')
   }, err => {
     assert.ok(/"dne"/.test(err.message))
@@ -478,7 +419,7 @@ test('filter bad column', assert => {
 })
 
 test('filter does not satisfy validator', assert => {
-  return NodeObjects.filter({'val': 'banana'}).then(() => {
+  return Node.objects.filter({'val': 'banana'}).then(() => {
     throw new Error('did not expect to make it this far')
   }, err => {
     assert.ok(/"val"/.test(err.message))
@@ -497,7 +438,7 @@ test('exclude or', assert => {
 })
 
 test('error from postgres in row count', assert => {
-  return NodeObjects.filter({
+  return Node.objects.filter({
     val: -1,
     'val:raw' () {
       return 'not valid sql'
@@ -511,12 +452,12 @@ test('error from postgres in row count', assert => {
 
 test('update ignores non-forward relations, non-ddl items', assert => {
   // just shouldn't explode!
-  return NodeObjects.filter({val: -1}).update({val: 1, refs: 'goof', newman: 'jerry'})
+  return Node.objects.filter({val: -1}).update({val: 1, refs: 'goof', newman: 'jerry'})
 })
 
 test('update throws on bad data validation', assert => {
   // just shouldn't explode!
-  return NodeObjects.filter([{val: -1}, {val: 100000}]).update({val: 'goof'}).then(() => {
+  return Node.objects.filter([{val: -1}, {val: 100000}]).update({val: 'goof'}).then(() => {
     throw new Error('did not expect to make it this far')
   }, err => {
     assert.ok(/"val".*must be a number/.test(err.message))
@@ -524,21 +465,21 @@ test('update throws on bad data validation', assert => {
 })
 
 test('update allows OR', assert => {
-  return NodeObjects.filter([{val: 10}, {val: 100}]).update({val: 0}).then(results => {
-    assert.equal(Number(results), 6)
+  return Node.objects.filter([{val: 10}, {val: 100}]).update({val: 0}).then(results => {
+    assert.equal(Number(results), 2)
   })
 })
 
 test('count() on annotated query', assert => {
-  const root = NodeObjects.create({name: 'count-annotation'})
-  const root2 = NodeObjects.create({name: 'count-annotation'})
-  const root3 = NodeObjects.create({name: 'count-annotation'})
+  const root = Node.objects.create({name: 'count-annotation', val: 0})
+  const root2 = Node.objects.create({name: 'count-annotation', val: 0})
+  const root3 = Node.objects.create({name: 'count-annotation', val: 0})
   const refs = Array.from(Array(20)).map((_, idx) => {
-    return RefObjects.create({node: root, val: idx})
+    return Ref.objects.create({node: root, val: idx})
   })
 
   return Promise.all(refs.concat([root2]).concat([root3])).then(() => {
-    const qs = NodeObjects.filter({name: 'count-annotation'}).annotate({
+    const qs = Node.objects.filter({name: 'count-annotation'}).annotate({
       total (ref) {
         return `sum(${ref('refs.val')})`
       }
@@ -551,11 +492,7 @@ test('count() on annotated query', assert => {
 })
 
 test('none() works as expected', assert => {
-  return NodeObjects.none().then(results => {
+  return Node.objects.none().then(results => {
     assert.equal(results.length, 0)
   })
-})
-
-test('drop database', function (assert) {
-  db.teardown().then(assert.end, assert.end)
 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -5,7 +5,7 @@ const { beforeEach, afterEach, teardown, test } = require('tap')
 
 const ormnomnom = require('..')
 const { Node, Ref, Farout } = require('./models')
-const db = require('./db.js')
+const db = require('./db')
 
 db.setup(beforeEach, afterEach, teardown)
 

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -64,6 +64,16 @@ test('test insert errors when validation fails', function (assert) {
   })
 })
 
+test('test insert fails when primary key conflicts', function (assert) {
+  return Node.objects.create({
+    id: 1,
+    name: 'broken',
+    val: 100
+  }).catch(err => {
+    assert.equals(err.message, 'duplicate key value violates unique constraint "nodes_pkey"')
+  })
+})
+
 test('test update (none affected)', assert => {
   return Node.objects
     .filter({'val:gt': 30000})

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -577,6 +577,20 @@ test('test group', assert => {
   })
 })
 
+test('test group (no annotations)', assert => {
+  return Ref.objects.create({ node_id: 3, val: 5 }).then(_ => {
+    return Ref.objects.all().group('node_id').order('-node_id')
+  }).then(xs => {
+    assert.match(xs, [{
+      node_id: 3
+    }, {
+      node_id: 2
+    }, {
+      node_id: 1
+    }])
+  })
+})
+
 test('test group (no column specified)', assert => {
   const getNode = Node.objects.create({
     val: 10,

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -147,6 +147,18 @@ test('test update (none affected)', assert => {
     })
 })
 
+test('test update with missing data', assert => {
+  return Node.objects.update().catch(err => {
+    assert.equals(err.message, 'Attempted update of Node object with no data')
+  })
+})
+
+test('test update', assert => {
+  return Node.objects.filter({ id: 1 }).update([{ name: 'janis joplin' }, null]).catch(err => {
+    assert.equals(err.message, 'Attempted update of Node object with no data')
+  })
+})
+
 test('test update (one affected)', assert => {
   return Node.objects
     .filter({'val': 3})

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -122,12 +122,13 @@ test('test insert errors when validation fails', assert => {
 })
 
 test('test insert fails when primary key conflicts', assert => {
+  ormnomnom.describeConflict('nodes_pkey', 'Node already exists')
   return Node.objects.create({
     id: 1,
     name: 'broken',
     val: 100
   }).catch(err => {
-    assert.equals(err.message, 'duplicate key value violates unique constraint "nodes_pkey"')
+    assert.equals(err.message, 'Node already exists')
   })
 })
 

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -132,6 +132,16 @@ test('test insert fails when primary key conflicts', assert => {
   })
 })
 
+test('test insert fails when primary key conflicts (no description available)', assert => {
+  return Ref.objects.create({
+    id: 1,
+    node_id: 1,
+    val: 100
+  }).catch(err => {
+    assert.equals(err.message, 'duplicate key value violates unique constraint "refs_pkey"')
+  })
+})
+
 test('test update (none affected)', assert => {
   return Node.objects
     .filter({'val:gt': 30000})

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -2,6 +2,7 @@
 
 const Promise = require('bluebird')
 const { beforeEach, afterEach, teardown, test } = require('tap')
+const { Writable } = require('stream')
 
 const ormnomnom = require('..')
 const { Node, Ref, Farout } = require('./models')
@@ -264,6 +265,27 @@ test('test deep values select', function (assert) {
       node_id: 2
     }])
     assert.ok(!(xs[0] instanceof Ref), 'should be plain objects')
+  })
+})
+
+test('test streaming select', function (assert) {
+  return new Promise((resolve, reject) => {
+    const receiver = new Writable({
+      write: function (chunk, _, callback) {
+        assert.deepEquals(chunk, {
+          id: 1,
+          name: 'HELLO',
+          val: 3
+        })
+        callback()
+      },
+      objectMode: true
+    })
+
+    receiver.on('error', reject)
+    receiver.on('finish', resolve)
+
+    Node.objects.filter({ id: 1 }).pipe(receiver)
   })
 })
 

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -235,6 +235,30 @@ test('test distinct', function (assert) {
   })
 })
 
+test('test slice', function (assert) {
+  return Node.objects.all().slice(0, 1).order('id').then(xs => {
+    assert.deepEqual(xs, [{
+      id: 1,
+      name: 'HELLO',
+      val: 3
+    }])
+  })
+})
+
+test('test slice with offset', function (assert) {
+  return Node.objects.all().slice(1, 3).order('id').then(xs => {
+    assert.deepEqual(xs, [{
+      id: 2,
+      name: 'Gary busey',
+      val: -10
+    }, {
+      id: 3,
+      name: 'John Bonham',
+      val: 10000
+    }])
+  })
+})
+
 test('test "in query" optimization', function (assert) {
   return Ref.objects.filter({
     'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -395,6 +395,26 @@ test('test bulk insert', function (assert) {
     })
 })
 
+test('test group', function (assert) {
+  return Ref.objects.create({
+    node_id: 2,
+    val: 5
+  }).then(_ => {
+    return Ref.objects.all().group('node_id').annotate({
+      highest (ref) {
+        return `max(${ref('val')})`
+      }
+    }).order('highest')
+  }).then(xs => {
+    assert.equals(xs.length, 3)
+    assert.match(xs, [
+      [{ node_id: 3 }, { highest: 0 }],
+      [{ node_id: 2 }, { highest: 5 }],
+      [{ node_id: 1 }, { highest: 10 }]
+    ])
+  })
+})
+
 test('test group (no column specified)', assert => {
   const getNode = Node.objects.create({
     val: 10,

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const Promise = require('bluebird')
-const { beforeEach, afterEach, teardown, test } = require('tap')
-const { Writable } = require('stream')
+const {beforeEach, afterEach, teardown, test} = require('tap')
+const {Writable} = require('stream')
 
 const ormnomnom = require('..')
-const { Node, Ref, Farout } = require('./models')
+const {Node, Ref, Farout} = require('./models')
 const db = require('./db')
 
 db.setup(beforeEach, afterEach, teardown)
@@ -165,7 +165,7 @@ test('test update with missing data', assert => {
 })
 
 test('test update', assert => {
-  return Node.objects.filter({ id: 1 }).update([{ name: 'janis joplin' }, null]).catch(err => {
+  return Node.objects.filter({id: 1}).update([{name: 'janis joplin'}, null]).catch(err => {
     assert.equals(err.message, 'Attempted update of Node object with no data')
   })
 })
@@ -214,7 +214,7 @@ test('test update (one affected, with join)', assert => {
 })
 
 test('test update (all affected)', assert => {
-  return Node.objects.update({ val: 14 }).then(xs => {
+  return Node.objects.update({val: 14}).then(xs => {
     assert.deepEqual(xs, 5)
     return db.getConnection()
   }).then(conn => {
@@ -248,7 +248,7 @@ test('test update (all affected)', assert => {
 
 test('test filter with delete', assert => {
   return Node.objects
-    .filter({ id: 1000 })
+    .filter({id: 1000})
     .delete()
     .then(xs => {
       assert.deepEqual(xs, 0)
@@ -264,7 +264,7 @@ test('test filter with delete', assert => {
 
 test('test delete', assert => {
   return Node.objects
-    .delete({ id: 1 })
+    .delete({id: 1})
     .then(xs => {
       assert.deepEqual(xs, 1)
       return db.getConnection()
@@ -280,7 +280,7 @@ test('test delete', assert => {
 
 test('test delete with or', assert => {
   return Node.objects
-    .delete([{ id: 1 }, { id: 2 }])
+    .delete([{id: 1}, {id: 2}])
     .then(xs => {
       assert.deepEqual(xs, 2)
       return db.getConnection()
@@ -320,7 +320,7 @@ test('test simple select', assert => {
       name: 'jake busey',
       val: -100
     })
-  }).then(_ => {
+  }).then(() => {
     return Ref.objects.filter({'node.name:startsWith': 'jake'}).then(xs => {
       assert.equal(xs.length, 1)
       assert.equal(xs[0].node.name, 'jake busey')
@@ -330,7 +330,7 @@ test('test simple select', assert => {
 })
 
 test('test select with or (with only one condition)', assert => {
-  return Node.objects.filter([{ id: 1 }]).then(xs => {
+  return Node.objects.filter([{id: 1}]).then(xs => {
     assert.deepEqual(xs, [{
       id: 1,
       name: 'HELLO',
@@ -359,7 +359,7 @@ test('test deep values select', assert => {
 })
 
 test('test select with order by joined column', assert => {
-  return Farout.objects.create({ ref_id: 1 }).then(_ => {
+  return Farout.objects.create({ref_id: 1}).then(() => {
     return Farout.objects.all().order('ref.node.id')
   }).then(xs => {
     assert.match(xs, [{
@@ -368,10 +368,21 @@ test('test select with order by joined column', assert => {
   })
 })
 
+test('test select with multiple joins', assert => {
+  return Farout.objects.create({ref_id: 1, second_ref_id: 2}).then(() => {
+    return Farout.objects.filter([{'ref.id': 1}, {'second_ref.id': 2}])
+  }).then(xs => {
+    assert.match(xs, [{
+      ref_id: 1,
+      second_ref_id: 2
+    }])
+  })
+})
+
 test('test streaming select', assert => {
   return new Promise((resolve, reject) => {
     const receiver = new Writable({
-      write: function (chunk, _, callback) {
+      write (chunk, _, callback) {
         assert.deepEquals(chunk, {
           id: 1,
           name: 'HELLO',
@@ -385,12 +396,12 @@ test('test streaming select', assert => {
     receiver.on('error', reject)
     receiver.on('finish', resolve)
 
-    Node.objects.filter({ id: 1 }).pipe(receiver)
+    Node.objects.filter({id: 1}).pipe(receiver)
   })
 })
 
 test('test onQuery fires', assert => {
-  const eventFired = new Promise((resolve) => {
+  const eventFired = new Promise(resolve => {
     const listener = function (cls, sql) {
       assert.equals(cls.name, 'Node')
       ormnomnom.removeQueryListener(listener)
@@ -401,14 +412,14 @@ test('test onQuery fires', assert => {
 
   return Promise.all([
     eventFired,
-    Node.objects.filter({ id: 1 }).then(xs => {
-      assert.match(xs[0], { id: 1, name: 'HELLO', val: 3 })
+    Node.objects.filter({id: 1}).then(xs => {
+      assert.match(xs[0], {id: 1, name: 'HELLO', val: 3})
     })
   ])
 })
 
 test('test distinct', assert => {
-  return Ref.objects.filter({ val: 0 }).distinct('val').then(xs => {
+  return Ref.objects.filter({val: 0}).distinct('val').then(xs => {
     assert.deepEqual(xs, [{
       node: null,
       id: 2,
@@ -419,7 +430,7 @@ test('test distinct', assert => {
 })
 
 test('test distinct with default column', assert => {
-  return Ref.objects.filter({ val: 0 }).distinct().then(xs => {
+  return Ref.objects.filter({val: 0}).distinct().then(xs => {
     assert.deepEqual(xs, [{
       node: null,
       id: 2,
@@ -474,7 +485,7 @@ test('test slice with no end', assert => {
 
 test('test notIn with query as param', assert => {
   return Ref.objects.filter({
-    'node_id:notIn': Node.objects.filter({ 'id:gt': 1 }).valuesList('id')
+    'node_id:notIn': Node.objects.filter({'id:gt': 1}).valuesList('id')
   }).then(xs => {
     assert.deepEqual(xs, [{
       id: 1,
@@ -487,8 +498,8 @@ test('test notIn with query as param', assert => {
 
 test('test gt with query as param (should throw validation error)', assert => {
   return Ref.objects.filter({
-    'node_id:gt': Node.objects.filter({ id: 1 }).valuesList('id')
-  }).then(_ => {
+    'node_id:gt': Node.objects.filter({id: 1}).valuesList('id')
+  }).then(() => {
     assert.fail('should not reach here')
   }).catch(err => {
     assert.equals(err.name, 'ValidationError')
@@ -568,7 +579,7 @@ test('test getOrCreate multiple objects returned', assert => {
     val: 0xdeadbeef
   })
 
-  return Node.objects.getOrCreate({name: cloneBusey.get('name')}).then(_ => {
+  return Node.objects.getOrCreate({name: cloneBusey.get('name')}).then(() => {
     throw new Error('should throw exception')
   }, err => {
     assert.equal(err.constructor, Node.objects.MultipleObjectsReturned)
@@ -629,7 +640,7 @@ test('test group', assert => {
   return Ref.objects.create({
     node_id: 2,
     val: 5
-  }).then(_ => {
+  }).then(() => {
     return Ref.objects.all().group('node_id').annotate({
       highest (ref) {
         return `max(${ref('val')})`
@@ -638,15 +649,15 @@ test('test group', assert => {
   }).then(xs => {
     assert.equals(xs.length, 3)
     assert.match(xs, [
-      [{ node_id: 3 }, { highest: 0 }],
-      [{ node_id: 2 }, { highest: 5 }],
-      [{ node_id: 1 }, { highest: 10 }]
+      [{node_id: 3}, {highest: 0}],
+      [{node_id: 2}, {highest: 5}],
+      [{node_id: 1}, {highest: 10}]
     ])
   })
 })
 
 test('test group (no annotations)', assert => {
-  return Ref.objects.create({ node_id: 3, val: 5 }).then(_ => {
+  return Ref.objects.create({node_id: 3, val: 5}).then(() => {
     return Ref.objects.all().group('node_id').order('-node_id')
   }).then(xs => {
     assert.match(xs, [{
@@ -666,9 +677,9 @@ test('test group (annotation using push)', assert => {
     }
   }).order('node_id').then(xs => {
     assert.match(xs, [
-      [{ node_id: 1 }, { matches: true }],
-      [{ node_id: 2 }, { matches: false }],
-      [{ node_id: 3 }, { matches: false }]
+      [{node_id: 1}, {matches: true}],
+      [{node_id: 2}, {matches: false}],
+      [{node_id: 3}, {matches: false}]
     ])
   })
 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -486,11 +486,12 @@ test('filter does not satisfy validator', assert => {
 })
 
 test('exclude or', assert => {
-  return NodeObjects.exclude([{val: 10}, {val: 0}]).order('name').then(results => {
+  return Node.objects.exclude([{val: 10}, {val: 0}]).order('name').then(results => {
     assert.deepEqual(results.map(xs => xs.name), [
-      'cat',
-      'goof',
-      'troop'
+      'Gary busey',
+      'HELLO',
+      'John Bonham',
+      'Mona Lisa'
     ])
   })
 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -32,6 +32,43 @@ test('test insert', assert => {
   })
 })
 
+test('test bulk insert', function (assert) {
+  return Node.objects.create([{
+    name: 'one',
+    val: 1
+  }, {
+    name: 'two',
+    val: 2
+  }]).then(xs => {
+    assert.equals(xs.length, 2)
+    assert.match(xs, [{
+      name: 'one',
+      val: 1
+    }, {
+      name: 'two',
+      val: 2
+    }])
+  })
+})
+
+test('test bulk insert with differing columns', function (assert) {
+  return Node.objects.create([{
+    name: 'one',
+    val: 1
+  }, {
+    val: 2
+  }]).then(xs => {
+    assert.equals(xs.length, 2)
+    assert.match(xs, [{
+      name: 'one',
+      val: 1
+    }, {
+      name: null,
+      val: 2
+    }])
+  })
+})
+
 test('test insert (skips keys that arent columns)', function (assert) {
   return Node.objects.create({
     name: 'hello world',

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -32,7 +32,7 @@ test('test insert', assert => {
   })
 })
 
-test('test bulk insert', function (assert) {
+test('test bulk insert', assert => {
   return Node.objects.create([{
     name: 'one',
     val: 1
@@ -51,7 +51,7 @@ test('test bulk insert', function (assert) {
   })
 })
 
-test('test bulk insert with differing columns', function (assert) {
+test('test bulk insert with differing columns', assert => {
   return Node.objects.create([{
     name: 'one',
     val: 1
@@ -69,7 +69,7 @@ test('test bulk insert with differing columns', function (assert) {
   })
 })
 
-test('test insert (skips keys that arent columns)', function (assert) {
+test('test insert (skips keys that arent columns)', assert => {
   return Node.objects.create({
     name: 'hello world',
     val: 3,
@@ -93,7 +93,7 @@ test('test insert (skips keys that arent columns)', function (assert) {
   })
 })
 
-test('test insert errors when validation fails', function (assert) {
+test('test insert errors when validation fails', assert => {
   return Node.objects.create({
     name: 'hello world'
   }).catch(err => {
@@ -101,7 +101,7 @@ test('test insert errors when validation fails', function (assert) {
   })
 })
 
-test('test insert fails when primary key conflicts', function (assert) {
+test('test insert fails when primary key conflicts', assert => {
   return Node.objects.create({
     id: 1,
     name: 'broken',
@@ -147,7 +147,7 @@ test('test update (one affected)', assert => {
     })
 })
 
-test('test update (one affected, with join)', function (assert) {
+test('test update (one affected, with join)', assert => {
   return Ref.objects.create({val: 0, node: Node.objects.get({name: 'Mona Lisa'})})
     .then(() => {
       const subquery = Ref.objects
@@ -170,7 +170,7 @@ test('test update (one affected, with join)', function (assert) {
     })
 })
 
-test('test update (all affected)', function (assert) {
+test('test update (all affected)', assert => {
   return Node.objects.update({ val: 14 }).then(xs => {
     assert.deepEqual(xs, 5)
     return db.getConnection()
@@ -203,7 +203,7 @@ test('test update (all affected)', function (assert) {
   })
 })
 
-test('test filter with delete', function (assert) {
+test('test filter with delete', assert => {
   return Node.objects
     .filter({ id: 1000 })
     .delete()
@@ -219,7 +219,7 @@ test('test filter with delete', function (assert) {
     })
 })
 
-test('test delete', function (assert) {
+test('test delete', assert => {
   return Node.objects
     .delete({ id: 1 })
     .then(xs => {
@@ -235,7 +235,7 @@ test('test delete', function (assert) {
     })
 })
 
-test('test delete with or', function (assert) {
+test('test delete with or', assert => {
   return Node.objects
     .delete([{ id: 1 }, { id: 2 }])
     .then(xs => {
@@ -252,7 +252,7 @@ test('test delete with or', function (assert) {
     })
 })
 
-test('test nested insert', function (assert) {
+test('test nested insert', assert => {
   const createRef = Ref.objects.create({
     val: 10,
     node: Node.objects.create({
@@ -270,7 +270,7 @@ test('test nested insert', function (assert) {
     })
 })
 
-test('test simple select', function (assert) {
+test('test simple select', assert => {
   return Ref.objects.create({
     val: 300,
     node: Node.objects.create({
@@ -286,7 +286,7 @@ test('test simple select', function (assert) {
   })
 })
 
-test('test select with or (with only one condition)', function (assert) {
+test('test select with or (with only one condition)', assert => {
   return Node.objects.filter([{ id: 1 }]).then(xs => {
     assert.deepEqual(xs, [{
       id: 1,
@@ -296,7 +296,7 @@ test('test select with or (with only one condition)', function (assert) {
   })
 })
 
-test('test values select', function (assert) {
+test('test values select', assert => {
   return Ref.objects.filter({'node.name:endsWith': 'busey'}).values('node_id').then(xs => {
     assert.deepEqual(xs, [{
       node_id: 2
@@ -305,7 +305,7 @@ test('test values select', function (assert) {
   })
 })
 
-test('test deep values select', function (assert) {
+test('test deep values select', assert => {
   return Ref.objects.filter({'node.name:endsWith': 'busey'}).values(['node.name', 'node_id']).then(xs => {
     assert.deepEqual(xs, [{
       node: {name: 'Gary busey'},
@@ -315,7 +315,7 @@ test('test deep values select', function (assert) {
   })
 })
 
-test('test streaming select', function (assert) {
+test('test streaming select', assert => {
   return new Promise((resolve, reject) => {
     const receiver = new Writable({
       write: function (chunk, _, callback) {
@@ -336,7 +336,7 @@ test('test streaming select', function (assert) {
   })
 })
 
-test('test onQuery fires', function (assert) {
+test('test onQuery fires', assert => {
   const eventFired = new Promise((resolve) => {
     const listener = function (cls, sql) {
       assert.equals(cls.name, 'Node')
@@ -354,7 +354,7 @@ test('test onQuery fires', function (assert) {
   ])
 })
 
-test('test distinct', function (assert) {
+test('test distinct', assert => {
   return Ref.objects.filter({ val: 0 }).distinct('val').then(xs => {
     assert.deepEqual(xs, [{
       node: null,
@@ -365,7 +365,7 @@ test('test distinct', function (assert) {
   })
 })
 
-test('test distinct with default column', function (assert) {
+test('test distinct with default column', assert => {
   return Ref.objects.filter({ val: 0 }).distinct().then(xs => {
     assert.deepEqual(xs, [{
       node: null,
@@ -381,7 +381,7 @@ test('test distinct with default column', function (assert) {
   })
 })
 
-test('test slice', function (assert) {
+test('test slice', assert => {
   return Node.objects.all().slice(0, 1).order('id').then(xs => {
     assert.deepEqual(xs, [{
       id: 1,
@@ -391,7 +391,7 @@ test('test slice', function (assert) {
   })
 })
 
-test('test slice with offset', function (assert) {
+test('test slice with offset', assert => {
   return Node.objects.all().slice(1, 3).order('id').then(xs => {
     assert.deepEqual(xs, [{
       id: 2,
@@ -405,7 +405,7 @@ test('test slice with offset', function (assert) {
   })
 })
 
-test('test slice with no end', function (assert) {
+test('test slice with no end', assert => {
   return Node.objects.all().slice(3).order('id').then(xs => {
     assert.deepEqual(xs, [{
       id: 4,
@@ -419,7 +419,7 @@ test('test slice with no end', function (assert) {
   })
 })
 
-test('test "in query" optimization', function (assert) {
+test('test "in query" optimization', assert => {
   return Ref.objects.filter({
     'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')
   }).sql.then(sql => {
@@ -427,7 +427,7 @@ test('test "in query" optimization', function (assert) {
   })
 })
 
-test('test "in query" optimization w/prepended value', function (assert) {
+test('test "in query" optimization w/prepended value', assert => {
   return Ref.objects.filter({
     'node.name': 'squidward',
     'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')
@@ -436,33 +436,33 @@ test('test "in query" optimization w/prepended value', function (assert) {
   })
 })
 
-test('test values list', function (assert) {
+test('test values list', assert => {
   return Ref.objects.filter({'node.name:endsWith': 'busey'}).valuesList(['node_id', 'node.val']).then(xs => {
     assert.deepEqual(xs, [2, -10])
   })
 })
 
-test('test count', function (assert) {
+test('test count', assert => {
   return Node.objects.filter({'val:gt': 10}).count().then(function (xs) {
     assert.equal(xs, '2')
   })
 })
 
-test('test getOrCreate already exists', function (assert) {
+test('test getOrCreate already exists', assert => {
   return Node.objects.getOrCreate({name: 'Gary busey', val: -10}).spread((created, xs) => {
     assert.equal(created, false)
     assert.equal(xs.name, 'Gary busey')
   })
 })
 
-test('test getOrCreate does not exist', function (assert) {
+test('test getOrCreate does not exist', assert => {
   return Node.objects.getOrCreate({name: 'johnny five', val: 100}).spread((created, xs) => {
     assert.equal(created, true)
     assert.equal(xs.name, 'johnny five')
   })
 })
 
-test('test getOrCreate multiple objects returned', function (assert) {
+test('test getOrCreate multiple objects returned', assert => {
   const cloneBusey = Node.objects.create({
     name: 'Gary busey',
     val: 0xdeadbeef
@@ -475,7 +475,7 @@ test('test getOrCreate multiple objects returned', function (assert) {
   })
 })
 
-test('test get fails on multiple objects returned', function (assert) {
+test('test get fails on multiple objects returned', assert => {
   return Node.objects.get({'name:contains': 'busey'}).catch(err => {
     assert.equal(err.constructor, Node.objects.MultipleObjectsReturned)
     assert.equal(err.message, 'Multiple Node objects returned')
@@ -483,7 +483,7 @@ test('test get fails on multiple objects returned', function (assert) {
   })
 })
 
-test('test get fails on zero objects returned', function (assert) {
+test('test get fails on zero objects returned', assert => {
   return Node.objects.get({'name': 'ford prefect'})
   .catch(Node.objects.NotFound, err => {
     assert.equal(err.message, 'Node not found')
@@ -491,7 +491,7 @@ test('test get fails on zero objects returned', function (assert) {
   })
 })
 
-test('test reverse relation', function (assert) {
+test('test reverse relation', assert => {
   return Node.objects.refsSetFor(
     Node.objects.get({name: 'Gary busey'})
   ).then(xs => {
@@ -501,13 +501,13 @@ test('test reverse relation', function (assert) {
   })
 })
 
-test('test reverse query', function (assert) {
+test('test reverse query', assert => {
   return Node.objects.filter({'refs.val:gt': 0}).then(xs => {
     assert.equal(xs.length, 1)
   })
 })
 
-test('test bulk insert', function (assert) {
+test('test bulk insert', assert => {
   const bulkInsert = Node.objects.create([{
     val: 100,
     name: 'jake busey'
@@ -525,7 +525,7 @@ test('test bulk insert', function (assert) {
     })
 })
 
-test('test group', function (assert) {
+test('test group', assert => {
   return Ref.objects.create({
     node_id: 2,
     val: 5

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -591,6 +591,20 @@ test('test group (no annotations)', assert => {
   })
 })
 
+test('test group (annotation using push)', assert => {
+  return Ref.objects.all().group('node_id').annotate({
+    matches (ref, push) {
+      return `bool_and(${ref('val')} = ${push(10)})`
+    }
+  }).order('node_id').then(xs => {
+    assert.match(xs, [
+      [{ node_id: 1 }, { matches: true }],
+      [{ node_id: 2 }, { matches: false }],
+      [{ node_id: 3 }, { matches: false }]
+    ])
+  })
+})
+
 test('test group (no column specified)', assert => {
   const getNode = Node.objects.create({
     val: 10,

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -122,6 +122,23 @@ test('test delete', function (assert) {
     })
 })
 
+test('test delete with or', function (assert) {
+  return Node.objects
+    .delete([{ id: 1 }, { id: 2 }])
+    .then(xs => {
+      assert.deepEqual(xs, 2)
+      return db.getConnection()
+    }).then(conn => {
+      return Promise.promisify(conn.connection.query.bind(conn.connection))(
+        'select * from nodes'
+      ).tap(() => conn.release())
+    }).then(results => {
+      assert.deepEqual(results.rows.length, 3, 'verify one row is removed')
+      assert.notOk(results.rows.find(row => row.id === 1), 'verify node 1 is removed')
+      assert.notOk(results.rows.find(row => row.id === 2), 'verify node 2 is removed')
+    })
+})
+
 test('test nested insert', function (assert) {
   const createRef = Ref.objects.create({
     val: 10,

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -462,6 +462,53 @@ test('test slice with no end', assert => {
   })
 })
 
+test('test notIn with query as param', assert => {
+  return Ref.objects.filter({
+    'node_id:notIn': Node.objects.filter({ 'id:gt': 1 }).valuesList('id')
+  }).then(xs => {
+    assert.deepEqual(xs, [{
+      id: 1,
+      node: null,
+      node_id: 1,
+      val: 10
+    }])
+  })
+})
+
+test('test gt with query as param (should throw validation error)', assert => {
+  return Ref.objects.filter({
+    'node_id:gt': Node.objects.filter({ id: 1 }).valuesList('id')
+  }).then(_ => {
+    assert.fail('should not reach here')
+  }).catch(err => {
+    assert.equals(err.name, 'ValidationError')
+    assert.equals(err.message, 'child "node_id:gt" fails because ["node_id:gt" must be a number, "node_id:gt" must be a number of milliseconds or valid date string]')
+  })
+})
+
+test('test in with query containing no filter as param', assert => {
+  return Ref.objects.filter({
+    'node_id:in': Node.objects.all().valuesList('id')
+  }).then(xs => {
+    assert.deepEquals(xs, [{
+      id: 1,
+      node: null,
+      node_id: 1,
+      val: 10
+    }, {
+      id: 2,
+      node: null,
+      node_id: 2,
+      val: 0
+    }, {
+      id: 3,
+      node: null,
+      node_id: 3,
+      val: 0
+    }])
+  })
+})
+
 test('test "in query" optimization', assert => {
   return Ref.objects.filter({
     'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -360,7 +360,7 @@ test('test group (no column specified, nonvalues)', assert => {
       'refs.id:isNull': false
     }).group().annotate({
       nerds (ref) {
-        return `array_agg(${ref('refs.val')})`
+        return `array_agg(${ref('refs.val')} order by "refs"."val")`
       }
     }).annotate({
       howMuch (ref) {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -32,6 +32,14 @@ test('test insert', assert => {
   })
 })
 
+test('test insert with falsey data', assert => {
+  return Farout.objects.create(null).then(xs => {
+    assert.match(xs, {
+      ref_id: null
+    })
+  })
+})
+
 test('test bulk insert', assert => {
   return Node.objects.create([{
     name: 'one',
@@ -65,6 +73,18 @@ test('test bulk insert with differing columns', assert => {
     }, {
       name: null,
       val: 2
+    }])
+  })
+})
+
+test('test bulk insert with falsey data', assert => {
+  return Farout.objects.create([{
+    ref_id: 1
+  }, null]).then(xs => {
+    assert.match(xs, [{
+      ref_id: 1
+    }, {
+      ref_id: null
     }])
   })
 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -358,6 +358,16 @@ test('test deep values select', assert => {
   })
 })
 
+test('test select with order by joined column', assert => {
+  return Farout.objects.create({ ref_id: 1 }).then(_ => {
+    return Farout.objects.all().order('ref.node.id')
+  }).then(xs => {
+    assert.match(xs, [{
+      ref_id: 1
+    }])
+  })
+})
+
 test('test streaming select', assert => {
   return new Promise((resolve, reject) => {
     const receiver = new Writable({

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -192,6 +192,17 @@ test('test deep values select', function (assert) {
   })
 })
 
+test('test distinct', function (assert) {
+  return Ref.objects.filter({ val: 0 }).distinct('val').then(xs => {
+    assert.deepEqual(xs, [{
+      node: null,
+      id: 2,
+      node_id: 2,
+      val: 0
+    }])
+  })
+})
+
 test('test "in query" optimization', function (assert) {
   return Ref.objects.filter({
     'node_id:in': Node.objects.filter({name: 'gary busey'}).valuesList('id')

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -463,7 +463,7 @@ test('test getOrCreate does not exist', function (assert) {
 })
 
 test('test getOrCreate multiple objects returned', function (assert) {
-  var cloneBusey = Node.objects.create({
+  const cloneBusey = Node.objects.create({
     name: 'Gary busey',
     val: 0xdeadbeef
   })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -83,8 +83,7 @@ test('test update (one affected, with join)', function (assert) {
         'select * from refs where val=1000'
       ).tap(() => conn.release())
     }).then(results => {
-      assert.deepEqual(results.rows, [{
-        id: 4,
+      assert.match(results.rows, [{
         node_id: 4,
         val: 1000
       }], 'independently verify presence in db')
@@ -341,9 +340,9 @@ test('test group (no column specified, nonvalues)', assert => {
       }
     }).order('-howMuch')
   }).then(results => {
-    assert.deepEqual(results, [
-      [{id: 15, name: 'floof', val: 66044}, {nerds: [1, 3, 5, 7, 9], howMuch: 25}],
-      [{id: 14, name: 'cat', val: 10}, {nerds: [0, 2, 4, 6, 8], howMuch: 20}]
+    assert.match(results, [
+      [{name: 'floof', val: 66044}, {nerds: [1, 3, 5, 7, 9], howMuch: 25}],
+      [{name: 'cat', val: 10}, {nerds: [0, 2, 4, 6, 8], howMuch: 20}]
     ])
   })
 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -122,6 +122,39 @@ test('test update (one affected, with join)', function (assert) {
     })
 })
 
+test('test update (all affected)', function (assert) {
+  return Node.objects.update({ val: 14 }).then(xs => {
+    assert.deepEqual(xs, 5)
+    return db.getConnection()
+  }).then(conn => {
+    return Promise.promisify(conn.connection.query.bind(conn.connection))(
+      'select * from nodes'
+    ).tap(() => conn.release())
+  }).then(results => {
+    assert.match(results.rows, [{
+      id: 1,
+      name: 'HELLO',
+      val: 14
+    }, {
+      id: 2,
+      name: 'Gary busey',
+      val: 14
+    }, {
+      id: 3,
+      name: 'John Bonham',
+      val: 14
+    }, {
+      id: 4,
+      name: 'Mona Lisa',
+      val: 14
+    }, {
+      id: 5,
+      name: null,
+      val: 14
+    }])
+  })
+})
+
 test('test filter with delete', function (assert) {
   return Node.objects
     .filter({ id: 1000 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -235,6 +235,22 @@ test('test distinct', function (assert) {
   })
 })
 
+test('test distinct with default column', function (assert) {
+  return Ref.objects.filter({ val: 0 }).distinct().then(xs => {
+    assert.deepEqual(xs, [{
+      node: null,
+      id: 2,
+      node_id: 2,
+      val: 0
+    }, {
+      node: null,
+      id: 3,
+      node_id: 3,
+      val: 0
+    }])
+  })
+})
+
 test('test slice', function (assert) {
   return Node.objects.all().slice(0, 1).order('id').then(xs => {
     assert.deepEqual(xs, [{
@@ -255,6 +271,20 @@ test('test slice with offset', function (assert) {
       id: 3,
       name: 'John Bonham',
       val: 10000
+    }])
+  })
+})
+
+test('test slice with no end', function (assert) {
+  return Node.objects.all().slice(3).order('id').then(xs => {
+    assert.deepEqual(xs, [{
+      id: 4,
+      name: 'Mona Lisa',
+      val: 100
+    }, {
+      id: 5,
+      name: null,
+      val: 10
     }])
   })
 })

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -238,6 +238,16 @@ test('test simple select', function (assert) {
   })
 })
 
+test('test select with or (with only one condition)', function (assert) {
+  return Node.objects.filter([{ id: 1 }]).then(xs => {
+    assert.deepEqual(xs, [{
+      id: 1,
+      name: 'HELLO',
+      val: 3
+    }])
+  })
+})
+
 test('test values select', function (assert) {
   return Ref.objects.filter({'node.name:endsWith': 'busey'}).values('node_id').then(xs => {
     assert.deepEqual(xs, [{

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -257,6 +257,24 @@ test('test deep values select', function (assert) {
   })
 })
 
+test('test onQuery fires', function (assert) {
+  const eventFired = new Promise((resolve) => {
+    const listener = function (cls, sql) {
+      assert.equals(cls.name, 'Node')
+      ormnomnom.removeQueryListener(listener)
+      resolve()
+    }
+    ormnomnom.onQuery(listener)
+  })
+
+  return Promise.all([
+    eventFired,
+    Node.objects.filter({ id: 1 }).then(xs => {
+      assert.match(xs[0], { id: 1, name: 'HELLO', val: 3 })
+    })
+  ])
+})
+
 test('test distinct', function (assert) {
   return Ref.objects.filter({ val: 0 }).distinct('val').then(xs => {
     assert.deepEqual(xs, [{


### PR DESCRIPTION
this is a pretty major overhaul of the tests, with a bonus bug fix snuck in there

## bug fixes

- the `exclude()` method failed when using an or statement and became synonymous with `filter()` due to a subtle inheritance bug in the where classes, this is fixed and the corresponding test updated to reflect the expected return values
- `create()` can now work with no data when a model does not require input (i.e. all columns are automatically generated or nullable) also `create([null])` will function the same way
- `update()` will return a specific error type informing the user they've failed to pass data
- `filter()` and `exclude()` now behave appropriately when called without parameters, with falsey parameters, or with empty objects. this is a bug fix as the previous behavior generated invalid sql in some cases

## test updates

- update tap to latest version
- switch to pgtools.{createdb/dropdb} instead of spawning shell tools
- move all schema and fixture creation to pretest, we now have a single source of truth for the state of data for every test
- move all fixture data into plain sql, this makes sure that initial data is extremely explicit and does not rely on ormnomnom behaviors at all
- move all models to a common module, eliminate some redundancies, and use consistent patterns (`Model.objects` vs `ModelObjects`)
- wrap all tests in transactions, anything you modify in your test will be reset for the next test restoring data to a known state (no more relying on side effects from previous tests)
  