### PR TITLE
Bugfixery

### DIFF
--- a/lib/private-api.js
+++ b/lib/private-api.js
@@ -177,6 +177,12 @@ function install (dao) {
       }
     }
   }
+
+  const pending = pendingInstallation.get(dao.InstanceCls) || []
+  pendingInstallation.delete(dao.InstanceCls)
+  pending.forEach(install => {
+    installReverse(install.dao, install.key, dao.publicAPI)
+  })
 }
 
 function installReverse (src, key, target) {

--- a/lib/sql/query-insert.js
+++ b/lib/sql/query-insert.js
@@ -18,10 +18,10 @@ module.exports = class Insert extends RowStreamQuery {
       if (!col.isFK) {
         returningKeys.push(col.name)
       }
-      if (key === dao.primaryKeyName && !(key in data)) {
-        continue
-      }
       validator[key] = col.getDataValidator()
+      if (key === dao.primaryKeyName) {
+        validator[key] = validator[key].optional()
+      }
     }
 
     const insertSchema = new Set()
@@ -51,7 +51,11 @@ module.exports = class Insert extends RowStreamQuery {
     for (let x = 0; x < preppedData.length; ++x) {
       const row = []
       for (const col of insertSchema) {
-        row.push('$' + this.values.push(preppedData[x][col]))
+        if (!(col in preppedData[x]) || (col === dao.primaryKeyName && !preppedData[x][col])) {
+          row.push('DEFAULT')
+        } else {
+          row.push('$' + this.values.push(preppedData[x][col]))
+        }
       }
       rows.push(`(${row.join(', ')})`)
     }

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -3,6 +3,7 @@
 const {beforeEach, afterEach, teardown, test} = require('tap')
 
 const ormnomnom = require('..')
+const symbols = require('../lib/shared-symbols')
 const db = require('./db')
 
 db.setup(beforeEach, afterEach, teardown)
@@ -29,5 +30,30 @@ test('throws if passed to two ormnomnoms', assert => {
     ormnomnom(TestFoo)
   })
 
+  assert.end()
+})
+
+test('correctly resolves foreign key classes when passed before assigned a dao', assert => {
+  class TestFoo {
+  }
+  class TestSubFoo {
+  }
+
+  TestFoo.objects = ormnomnom(TestFoo, {
+    id: ormnomnom.joi.number(),
+    sub: ormnomnom.fk(TestSubFoo)
+  })
+
+  const privateAPISym = Object.getOwnPropertySymbols(TestFoo.objects)[0]
+  assert.equals(TestFoo.objects[privateAPISym].ddl.sub.cls, TestSubFoo, 'sub class should be TestSubFoo')
+  // Symbol counting is kind of a hacky way to test this, but the missing cls-to-dao symbol tells us that the
+  // class is not yet registered, and the follow up assertion ensures that the class gets registered properly later
+  assert.equals(Object.getOwnPropertySymbols(TestFoo.objects[privateAPISym].ddl.sub.cls).length, 0, 'should have no symbols')
+
+  TestSubFoo.objects = ormnomnom(TestSubFoo, {
+    id: ormnomnom.joi.number()
+  })
+
+  assert.equals(Object.getOwnPropertySymbols(TestFoo.objects[privateAPISym].ddl.sub.cls).length, 1, 'should have one symbol')
   assert.end()
 })

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -3,7 +3,6 @@
 const {beforeEach, afterEach, teardown, test} = require('tap')
 
 const ormnomnom = require('..')
-const symbols = require('../lib/shared-symbols')
 const db = require('./db')
 
 db.setup(beforeEach, afterEach, teardown)

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -127,6 +127,8 @@ test('test insert fails when primary key conflicts', assert => {
     id: 1,
     name: 'broken',
     val: 100
+  }).then(() => {
+    assert.fail('should not be reachable')
   }).catch(err => {
     assert.equals(err.message, 'Node already exists')
   })
@@ -137,6 +139,8 @@ test('test insert fails when primary key conflicts (no description available)', 
     id: 1,
     node_id: 1,
     val: 100
+  }).then(() => {
+    assert.fail('should not be reachable')
   }).catch(err => {
     assert.equals(err.message, 'duplicate key value violates unique constraint "refs_pkey"')
   })


### PR DESCRIPTION
This resolves two issues, one that was erroneously removed during the initial cleanup phase (the reverse installation loop), and one that was mishandled both initially and after the cleanup phase.

The reverse installation loop is necessary for instances where a class is defined as a foreign key, but has not yet itself been wrapped as a DAO. The test for this one is a little hacky, but effective.

The insert query problem is that primary keys were _always_ being dropped during an insert due to the test for `key in data` since `data` is an array. I've worked around this by explicitly forcing primary key validators to optional and passing `DEFAULT` as the value if one was not specified.