### PR TITLE
Decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ PackageObjects.filter({'author.name:startsWith': 'Gary'}).then(objects => {
   * [Getting Started with ORMnomnom](docs/getting-started.md)
   * [Building models](docs/building-models.md)
   * [Making queries](docs/making-queries.md)
+  * [Decorators](docs/decorators.md)
 * **Reference documentation**
   * [Data access objects](docs/ref/dao.md)
   * [QuerySets](docs/ref/queryset.md)

--- a/decorators/autonow.js
+++ b/decorators/autonow.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const clone = require('clone')
+const Promise = require('bluebird')
+
+const symbols = require('../lib/shared-symbols')
+const privateAPISym = symbols.privateAPI
+const DAO = require('..')
+
+const autoNowSym = Symbol('auto_now')
+
+module.exports = function (dao, opts = {}) {
+  if (!(dao instanceof DAO)) {
+    throw new Error('Expected instance of DAO')
+  }
+
+  if (!opts.column) {
+    throw new Error('Must specify column name for automatic timestamps')
+  }
+  const column = opts.column
+  const createOnly = 'createOnly' in opts ? opts.createOnly : false
+
+  if (dao[autoNowSym] && dao[autoNowSym].has(column)) {
+    throw new Error(`The column "${column}" is already configured for automatic timestamps`)
+  }
+
+  const wrappedDao = clone(dao)
+  // We also have to manually copy getQuerySet(), clone skips it since
+  // it's part of the original prototype
+  wrappedDao[privateAPISym].getQuerySet = dao[privateAPISym].getQuerySet
+
+  if (!wrappedDao[autoNowSym]) {
+    wrappedDao[autoNowSym] = new Set()
+  }
+  wrappedDao[autoNowSym].add(column)
+
+  const privateAPI = wrappedDao[privateAPISym]
+  const queryset = privateAPI.getQuerySet()
+
+  class AutoNowQuerySet extends queryset.constructor {
+    create (data) {
+      const isBulk = Array.isArray(data)
+      const getData = isBulk
+          ? Promise.all(data.map(xs => Promise.props(xs || {})))
+          : Promise.props(data || {}).then(xs => [xs])
+
+      return getData.then(data => {
+        const wrapped = data.map(props => {
+          if (!(column in props) || !props[column]) {
+            props[column] = new Date()
+          }
+          return props
+        })
+
+        return super.create(isBulk ? wrapped : wrapped[0])
+      })
+    }
+
+    update (data) {
+      if (createOnly) {
+        return super.update(data)
+      }
+
+      return Promise.props(data || {}).then(props => {
+        if (!(column in props) || !props[column]) {
+          props[column] = new Date()
+        }
+
+        return super.update(props)
+      })
+    }
+  }
+
+  privateAPI.getQuerySet = function () {
+    return new AutoNowQuerySet(this, null)
+  }.bind(privateAPI)
+
+  return wrappedDao
+}

--- a/decorators/autonow.js
+++ b/decorators/autonow.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const clone = require('clone')
+const clone = require('lodash.clonedeep')
 const Promise = require('bluebird')
 
 const symbols = require('../lib/shared-symbols')
@@ -29,11 +29,6 @@ module.exports = function (dao, opts = {}) {
   }
 
   const wrappedDao = clone(dao)
-  // We also have to manually copy getQuerySet(), clone skips it since
-  // it's part of the original prototype
-  wrappedDao[privateAPISym].getQuerySet = dao[privateAPISym].getQuerySet
-  wrappedDao.all = dao.all
-
   if (!wrappedDao[autoNowSym]) {
     wrappedDao[autoNowSym] = new Set()
   }

--- a/decorators/autonow.js
+++ b/decorators/autonow.js
@@ -18,6 +18,10 @@ module.exports = function (dao, opts = {}) {
     throw new Error('Must specify column name for automatic timestamps')
   }
   const column = opts.column
+  if (!(column in dao[privateAPISym].ddl) || dao[privateAPISym].ddl[column].isFK) {
+    throw new Error(`Column "${column}" does not exist and cannot be configured for automatic timestamps`)
+  }
+
   const createOnly = 'createOnly' in opts ? opts.createOnly : false
 
   if (dao[autoNowSym] && dao[autoNowSym].has(column)) {
@@ -28,6 +32,7 @@ module.exports = function (dao, opts = {}) {
   // We also have to manually copy getQuerySet(), clone skips it since
   // it's part of the original prototype
   wrappedDao[privateAPISym].getQuerySet = dao[privateAPISym].getQuerySet
+  wrappedDao.all = dao.all
 
   if (!wrappedDao[autoNowSym]) {
     wrappedDao[autoNowSym] = new Set()

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -36,11 +36,11 @@ module.exports = function (dao, opts = {}) {
 
   class SoftDeleteQuerySet extends queryset.constructor {
     get (query) {
-      return super.get(Object.assign({}, { [`${column}:isNull`]: true }, query))
+      return super.get(Object.assign({}, {[`${column}:isNull`]: true}, query))
     }
 
     filter (query) {
-      const q = Object.assign({}, { [`${column}:isNull`]: true }, query)
+      const q = Object.assign({}, {[`${column}:isNull`]: true}, query)
 
       for (const key in q) {
         const path = key.split(':')[0]
@@ -61,12 +61,12 @@ module.exports = function (dao, opts = {}) {
     }
 
     delete () {
-      return super.update({ [column]: new Date() })
+      return super.update({[column]: new Date()})
     }
   }
 
   wrappedDao.all = function () {
-    return this.getQuerySet().filter({ [`${column}:isNull`]: true })
+    return this.getQuerySet().filter({[`${column}:isNull`]: true})
   }.bind(wrappedDao)
 
   privateAPI.getQuerySet = function () {

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -41,7 +41,18 @@ module.exports = function (dao, opts = {}) {
     }
 
     filter (query) {
-      return super.filter(Object.assign({}, { 'deleted:isNull': true }, query))
+      const q = Object.assign({}, { 'deleted:isNull': true }, query)
+
+      for (const key in q) {
+        const path = key.split(':')[0]
+        const bits = path.split('.')
+        for (let i = 0; i < bits.length - 1; ++i) {
+          const segment = bits.slice(0, i + 1).join('.')
+          q[`${segment}.deleted:isNull`] = true
+        }
+      }
+
+      return super.filter(q)
     }
 
     delete () {

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -61,7 +61,7 @@ module.exports = function (dao, opts = {}) {
     }
 
     delete () {
-      return super.update({ deleted: new Date() })
+      return super.update({ [column]: new Date() })
     }
   }
 

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const clone = require('clone')
+
+const symbols = require('../lib/shared-symbols')
+const privateAPISym = symbols.privateAPI
+const DAO = require('..')
+
+const softDeleteSym = Symbol('soft_delete')
+
+module.exports = function (dao, opts = {}) {
+  if (!(dao instanceof DAO)) {
+    throw new Error('Expected instance of DAO')
+  }
+
+  if (!opts.column) {
+    throw new Error('Must specify column name for soft deletions')
+  }
+  const column = opts.column
+
+  if (dao[softDeleteSym] && dao[softDeleteSym].has(column)) {
+    throw new Error(`The column "${column}" is already configured for soft deletions`)
+  }
+
+  const wrappedDao = clone(dao)
+  // We also have to manually copy getQuerySet(), clone skips it since
+  // it's part of the original prototype
+  wrappedDao[privateAPISym].getQuerySet = dao[privateAPISym].getQuerySet
+
+  if (!wrappedDao[softDeleteSym]) {
+    wrappedDao[softDeleteSym] = new Set()
+  }
+  wrappedDao[softDeleteSym].add(column)
+
+  const privateAPI = wrappedDao[privateAPISym]
+  const queryset = privateAPI.getQuerySet()
+
+  class SoftDeleteQuerySet extends queryset.constructor {
+    get (query) {
+      return super.get(Object.assign({}, { 'deleted:isNull': true }, query))
+    }
+
+    filter (query) {
+      return super.filter(Object.assign({}, { 'deleted:isNull': true }, query))
+    }
+
+    delete () {
+      return super.update({ deleted: new Date() })
+    }
+  }
+
+  wrappedDao.all = function () {
+    return this.getQuerySet().filter({ 'deleted:isNull': true })
+  }.bind(wrappedDao)
+
+  privateAPI.getQuerySet = function () {
+    return new SoftDeleteQuerySet(this, null)
+  }.bind(privateAPI)
+
+  return wrappedDao
+}

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const clone = require('clone')
+const clone = require('lodash.clonedeep')
 
 const symbols = require('../lib/shared-symbols')
 const clsToDAOSym = symbols.clsToDAO
@@ -31,11 +31,6 @@ module.exports = function (dao, opts = {}) {
   dao[softDeleteSym] = column
 
   const wrappedDao = clone(dao)
-  // We also have to manually copy getQuerySet(), clone skips it since
-  // it's part of the original prototype
-  wrappedDao[privateAPISym].getQuerySet = dao[privateAPISym].getQuerySet
-  wrappedDao.all = dao.all
-
   const privateAPI = wrappedDao[privateAPISym]
   const queryset = privateAPI.getQuerySet()
 

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -9,7 +9,6 @@ const DAO = require('..')
 
 const softDeleteSym = Symbol('soft_delete')
 
-module.exports.symbol = softDeleteSym
 module.exports = function (dao, opts = {}) {
   if (!(dao instanceof DAO)) {
     throw new Error('Expected instance of DAO')

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -3,11 +3,13 @@
 const clone = require('clone')
 
 const symbols = require('../lib/shared-symbols')
+const clsToDAOSym = symbols.clsToDAO
 const privateAPISym = symbols.privateAPI
 const DAO = require('..')
 
 const softDeleteSym = Symbol('soft_delete')
 
+module.exports.symbol = softDeleteSym
 module.exports = function (dao, opts = {}) {
   if (!(dao instanceof DAO)) {
     throw new Error('Expected instance of DAO')
@@ -17,38 +19,47 @@ module.exports = function (dao, opts = {}) {
     throw new Error('Must specify column name for soft deletions')
   }
   const column = opts.column
-
-  if (dao[softDeleteSym] && dao[softDeleteSym].has(column)) {
-    throw new Error(`The column "${column}" is already configured for soft deletions`)
+  if (!(column in dao[privateAPISym].ddl) || dao[privateAPISym].ddl[column].isFK) {
+    throw new Error(`Column "${column}" does not exist and cannot be configured for soft deletions`)
   }
+
+  if (dao[softDeleteSym] && dao[softDeleteSym] !== column) {
+    throw new Error(`The column "${dao[softDeleteSym]}" is already configured for soft deletions`)
+  }
+
+  // We save the column name on the original dao before cloning so that we can reference it
+  // while generating filters for joins later
+  dao[softDeleteSym] = column
 
   const wrappedDao = clone(dao)
   // We also have to manually copy getQuerySet(), clone skips it since
   // it's part of the original prototype
   wrappedDao[privateAPISym].getQuerySet = dao[privateAPISym].getQuerySet
-
-  if (!wrappedDao[softDeleteSym]) {
-    wrappedDao[softDeleteSym] = new Set()
-  }
-  wrappedDao[softDeleteSym].add(column)
+  wrappedDao.all = dao.all
 
   const privateAPI = wrappedDao[privateAPISym]
   const queryset = privateAPI.getQuerySet()
 
   class SoftDeleteQuerySet extends queryset.constructor {
     get (query) {
-      return super.get(Object.assign({}, { 'deleted:isNull': true }, query))
+      return super.get(Object.assign({}, { [`${column}:isNull`]: true }, query))
     }
 
     filter (query) {
-      const q = Object.assign({}, { 'deleted:isNull': true }, query)
+      const q = Object.assign({}, { [`${column}:isNull`]: true }, query)
 
       for (const key in q) {
         const path = key.split(':')[0]
         const bits = path.split('.')
+        let ddl = wrappedDao[privateAPISym].ddl
         for (let i = 0; i < bits.length - 1; ++i) {
-          const segment = bits.slice(0, i + 1).join('.')
-          q[`${segment}.deleted:isNull`] = true
+          const reference = bits[i]
+          if (!(reference in ddl) || !(softDeleteSym in ddl[reference].cls[clsToDAOSym])) {
+            break
+          }
+          const segment = bits.slice(0, i + 1)
+          q[`${segment.join('.')}.${ddl[reference].cls[clsToDAOSym][softDeleteSym]}:isNull`] = true
+          ddl = ddl[reference].cls[clsToDAOSym][privateAPISym].ddl
         }
       }
 
@@ -61,7 +72,7 @@ module.exports = function (dao, opts = {}) {
   }
 
   wrappedDao.all = function () {
-    return this.getQuerySet().filter({ 'deleted:isNull': true })
+    return this.getQuerySet().filter({ [`${column}:isNull`]: true })
   }.bind(wrappedDao)
 
   privateAPI.getQuerySet = function () {

--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -49,7 +49,7 @@ module.exports = function (dao, opts = {}) {
         for (let i = 0; i < bits.length - 1; ++i) {
           const reference = bits[i]
           if (!(reference in ddl) || !(softDeleteSym in ddl[reference].cls[clsToDAOSym])) {
-            break
+            continue
           }
           const segment = bits.slice(0, i + 1)
           q[`${segment.join('.')}.${ddl[reference].cls[clsToDAOSym][softDeleteSym]}:isNull`] = true

--- a/decorators/timestamps.js
+++ b/decorators/timestamps.js
@@ -12,5 +12,5 @@ const defaults = {
 module.exports = function (dao, opts = {}) {
   const options = Object.assign({}, defaults, opts)
 
-  return autoNow(autoNow(softDelete(dao, { column: options.deleted }), { column: options.updated }), { column: options.created, createOnly: true })
+  return autoNow(autoNow(softDelete(dao, {column: options.deleted}), {column: options.updated}), {column: options.created, createOnly: true})
 }

--- a/decorators/timestamps.js
+++ b/decorators/timestamps.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const autoNow = require('./autonow')
-const safeDelete = require('./safeDelete')
+const softDelete = require('./softdelete')
 
 const defaults = {
   created: 'created',
@@ -12,5 +12,5 @@ const defaults = {
 module.exports = function (dao, opts = {}) {
   const options = Object.assign({}, defaults, opts)
 
-  return autoNow(autoNow(safeDelete(dao, { column: options.deleted }), { column: options.updated }), { column: options.created, createOnly: true })
+  return autoNow(autoNow(softDelete(dao, { column: options.deleted }), { column: options.updated }), { column: options.created, createOnly: true })
 }

--- a/decorators/timestamps.js
+++ b/decorators/timestamps.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const autoNow = require('./autonow')
+const safeDelete = require('./safeDelete')
+
+const defaults = {
+  created: 'created',
+  updated: 'updated',
+  deleted: 'deleted'
+}
+
+module.exports = function (dao, opts = {}) {
+  const options = Object.assign({}, defaults, opts)
+
+  return autoNow(autoNow(safeDelete(dao, { column: options.deleted }), { column: options.updated }), { column: options.created, createOnly: true })
+}

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -1,0 +1,99 @@
+# Decorators
+
+ORMnomnom includes a couple of decorators to make working with your models a little easier.
+
+## autoNow
+
+First there's the `autonow` decorator which will automatically set timestamps on a column on `.create()` and (optionally) `.update()`. It is used like so:
+
+
+```javascript
+const orm = require('ormnomnom')
+const autoNow = require('ormnomnom/decorators/autonow')
+
+class Book {
+  constructor ({id, title, publish_date, byline}={}) {
+    this.id = id
+    this.created = created
+    this.updated = updated
+    this.title = title
+    this.byline = byline
+  }
+}
+
+Book.rawObjects = orm(Book, {
+  id: orm.joi.number(),
+  title: orm.joi.string().required(),
+  publish_date: orm.joi.date(),
+  byline: orm.joi.string()
+})
+
+Book.objects = autoNow(Book.rawObjects, { column: 'created', createOnly: true }) // createOnly defaults to false
+Book.objects = autoNow(Book.objects, { column: 'updated' })
+```
+
+You'll note that we first create a DAO at `Book.rawObjects` before assigning a decorated DAO to `Book.objects`. This allows us to use the convenience features of the decorator when we want them (via `Book.objects`) and skip them when we don't (via `Book.rawObjects`). You'll also see that we're decorating our already decorated DAO with a second column, this allows us to have different behavior for multiple columns.
+
+In the above example, the `created` column will be set when an object is created, but will be left alone when the object is updated. The `updated` column will be set on create, as well as every time an object is updated.
+
+Here's a bit of example code to illustrate this behavior:
+
+```javascript
+return Book.objects.create({ title: 'John Dies at the End' }).then(book => {
+  assert.ok(book.created != null, 'created has been set')
+  assert.ok(book.updated != null, 'updated has been set')
+  return Book.objects.filter({ id: book.id }).update({ byline: 'STOP. You should not have touched this book with your bare hands.' }).then(updatedBook => {
+    assert.ok(book.created.getTime() === updatedBook.created.getTime(), 'created column has NOT been modified')
+    assert.ok(book.updated.getTime() < updatedBook.updated.getTime(), 'updated column HAS been modified')
+  })
+})
+```
+
+## softDelete
+
+The `softdelete` decorator overrides the `.delete()` method to instead write a timestamp on a column. It additionally intercepts the various read methods `.all()`, `.get()` and `.filter()` to additionally filter out rows which have the specified column set (as in, not `null`).
+
+Its usage can be illustrated like so (building off of the `Book` model from the above examples):
+
+```javascript
+const softDelete = require('ormnomnom/decorators/softdelete')
+
+Book.objects = softDelete(Book.objects, { column: 'deleted' })
+
+return Book.objects.filter({ title: 'John Dies at the End' }).delete().then(count => {
+  assert.ok(count === 1, 'deleted one row')
+  return Book.objects.filter({ title: 'John Dies at the End' })
+}).then(books => {
+  assert.ok(books.length === 0, 'returns no rows')
+  return Book.rawObjects.filter({ title: 'John Dies at the End' })
+}).then(books => {
+  assert.ok(books.length === 1, 'returns one row (because the row still exists)')
+  assert.ok(books[0].deleted != null, 'the deleted column has been set')
+  return Book.objects.get({ id: books[0].id }).catch(Book.objects.NotFound, err => {
+    assert.pass('NotFound is raised even though we tried to get the row by id')
+    return Book.objects.all()
+  })
+}).then(allBooks => {
+  assert.ok(books.length === 0, 'all() returns no books as well')
+})
+```
+
+## timestamps
+
+In addition to the above two decorators, a third `timestamps` middleware exists which combines the above patterns into a single convenience function. These three lines:
+
+```javascript
+Book.objects = softDelete(Book.rawObjects, { column: 'deleted' })
+Book.objects = autoNow(Book.objects, { column: 'updated' })
+Book.objects = autoNow(Book.objects, { column: 'created', createOnly: true })
+```
+
+Can be replaced with the following:
+
+```javascript
+const timestamps = require('ormnomnom/decorators/timestamps')
+
+Book.objects = timestamps(Book.rawObjects, { created: 'created', updated: 'updated', deleted: 'deleted' })
+// Note that the above is actually the default settings, and as such this can be done even more simply as
+// Book.objects = timestamps(Book.rawObjects)
+```

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -12,10 +12,11 @@ const orm = require('ormnomnom')
 const autoNow = require('ormnomnom/decorators/autonow')
 
 class Book {
-  constructor ({id, title, publish_date, byline}={}) {
+  constructor ({id, created, updated, deleted, title, byline}={}) {
     this.id = id
     this.created = created
     this.updated = updated
+    this.deleted = deleted
     this.title = title
     this.byline = byline
   }
@@ -23,13 +24,15 @@ class Book {
 
 Book.rawObjects = orm(Book, {
   id: orm.joi.number(),
+  created: orm.joi.date(),
+  updated: orm.joi.date(),
+  deleted: orm.joi.date(),
   title: orm.joi.string().required(),
-  publish_date: orm.joi.date(),
   byline: orm.joi.string()
 })
 
-Book.objects = autoNow(Book.rawObjects, { column: 'created', createOnly: true }) // createOnly defaults to false
-Book.objects = autoNow(Book.objects, { column: 'updated' })
+Book.objects = autoNow(Book.rawObjects, {column: 'created', createOnly: true}) // createOnly defaults to false
+Book.objects = autoNow(Book.objects, {column: 'updated'})
 ```
 
 You'll note that we first create a DAO at `Book.rawObjects` before assigning a decorated DAO to `Book.objects`. This allows us to use the convenience features of the decorator when we want them (via `Book.objects`) and skip them when we don't (via `Book.rawObjects`). You'll also see that we're decorating our already decorated DAO with a second column, this allows us to have different behavior for multiple columns.
@@ -39,10 +42,10 @@ In the above example, the `created` column will be set when an object is created
 Here's a bit of example code to illustrate this behavior:
 
 ```javascript
-return Book.objects.create({ title: 'John Dies at the End' }).then(book => {
+return Book.objects.create({title: 'John Dies at the End'}).then(book => {
   assert.ok(book.created != null, 'created has been set')
   assert.ok(book.updated != null, 'updated has been set')
-  return Book.objects.filter({ id: book.id }).update({ byline: 'STOP. You should not have touched this book with your bare hands.' }).then(updatedBook => {
+  return Book.objects.filter({id: book.id}).update({byline: 'STOP. You should not have touched this book with your bare hands.'}).then(updatedBook => {
     assert.ok(book.created.getTime() === updatedBook.created.getTime(), 'created column has NOT been modified')
     assert.ok(book.updated.getTime() < updatedBook.updated.getTime(), 'updated column HAS been modified')
   })
@@ -58,18 +61,18 @@ Its usage can be illustrated like so (building off of the `Book` model from the 
 ```javascript
 const softDelete = require('ormnomnom/decorators/softdelete')
 
-Book.objects = softDelete(Book.objects, { column: 'deleted' })
+Book.objects = softDelete(Book.objects, {column: 'deleted'})
 
-return Book.objects.filter({ title: 'John Dies at the End' }).delete().then(count => {
+return Book.objects.filter({title: 'John Dies at the End'}).delete().then(count => {
   assert.ok(count === 1, 'deleted one row')
-  return Book.objects.filter({ title: 'John Dies at the End' })
+  return Book.objects.filter({title: 'John Dies at the End'})
 }).then(books => {
   assert.ok(books.length === 0, 'returns no rows')
-  return Book.rawObjects.filter({ title: 'John Dies at the End' })
+  return Book.rawObjects.filter({title: 'John Dies at the End'})
 }).then(books => {
   assert.ok(books.length === 1, 'returns one row (because the row still exists)')
   assert.ok(books[0].deleted != null, 'the deleted column has been set')
-  return Book.objects.get({ id: books[0].id }).catch(Book.objects.NotFound, err => {
+  return Book.objects.get({id: books[0].id}).catch(Book.objects.NotFound, err => {
     assert.pass('NotFound is raised even though we tried to get the row by id')
     return Book.objects.all()
   })
@@ -83,9 +86,9 @@ return Book.objects.filter({ title: 'John Dies at the End' }).delete().then(coun
 In addition to the above two decorators, a third `timestamps` middleware exists which combines the above patterns into a single convenience function. These three lines:
 
 ```javascript
-Book.objects = softDelete(Book.rawObjects, { column: 'deleted' })
-Book.objects = autoNow(Book.objects, { column: 'updated' })
-Book.objects = autoNow(Book.objects, { column: 'created', createOnly: true })
+Book.objects = softDelete(Book.rawObjects, {column: 'deleted'})
+Book.objects = autoNow(Book.objects, {column: 'updated'})
+Book.objects = autoNow(Book.objects, {column: 'created', createOnly: true})
 ```
 
 Can be replaced with the following:

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -8,6 +8,9 @@ module.exports.describeConflict = describeConflict
 
 const Promise = require('bluebird')
 
+// These are required here so they can cache references to the private symbols
+require('../decorators/autonow')
+
 const symbols = require('./shared-symbols.js')
 const queryEventSym = symbols.queryEvent
 const privateAPISym = symbols.privateAPI

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -10,6 +10,7 @@ const Promise = require('bluebird')
 
 // These are required here so they can cache references to the private symbols
 require('../decorators/autonow')
+require('../decorators/softdelete')
 
 const symbols = require('./shared-symbols.js')
 const queryEventSym = symbols.queryEvent

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -43,7 +43,7 @@ class QuerySet {
   }
 
   count () {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._Query = Select
     qs._order = []
 
@@ -76,13 +76,13 @@ class QuerySet {
   }
 
   group (by = this[daoSym].primaryKeyName) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._grouping = [].concat(by)
     return qs
   }
 
   aggregate (agg) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._grouping = []
     qs._order = []
     return qs.annotate({
@@ -91,20 +91,20 @@ class QuerySet {
   }
 
   annotate (ann) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._Query = Select
     qs._annotation = ann
     return qs
   }
 
   distinct (expr = [this[daoSym].primaryKeyName]) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._distinct = [].concat(expr)
     return qs
   }
 
   order (by) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._order = [].concat(by)
     return qs
   }
@@ -134,7 +134,7 @@ class QuerySet {
   }
 
   filter (query) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._filter = query
     return qs
   }
@@ -143,14 +143,14 @@ class QuerySet {
     if (!query) {
       return this
     }
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     query[NEGATE_SYM] = true
     qs._filter = query
     return qs
   }
 
   slice (start, end) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     switch (arguments.length) {
       case 1:
         qs._slice = [start, Infinity]
@@ -163,7 +163,7 @@ class QuerySet {
   }
 
   delete (query) {
-    const qs = new QuerySet(this[daoSym], (
+    const qs = new this.constructor(this[daoSym], (
       query
       ? this.filter(query)
       : this
@@ -174,7 +174,7 @@ class QuerySet {
   }
 
   update (data) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     qs._Query = Update
     qs._data = data
     qs._transformer = (row, push) => push(row)
@@ -192,7 +192,7 @@ class QuerySet {
         return []
       }
 
-      const qs = new QuerySet(this[daoSym], this)
+      const qs = new this.constructor(this[daoSym], this)
       qs._Query = Insert
       qs._data = data
       return qs.then(xs => {
@@ -204,7 +204,7 @@ class QuerySet {
   }
 
   values (values) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     values = [].concat(values)
     qs._columns = values
     qs._transformer = this[daoSym].createValuesTransformer(values)
@@ -212,7 +212,7 @@ class QuerySet {
   }
 
   valuesList (values) {
-    const qs = new QuerySet(this[daoSym], this)
+    const qs = new this.constructor(this[daoSym], this)
     values = [].concat(values)
     qs._columns = values
     qs._transformer = this[daoSym].createValuesListTransformer(values)

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,11 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,11 +382,6 @@
         }
       }
     },
-    "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2121,6 +2116,11 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "pretest": "node -e 'require(\"./test/db\").createdb()'",
     "test": "TZ=UTC tap test/*-test.js",
     "posttest": "standard",
+    "pretest-cov": "npm run pretest",
     "test-cov": "TZ=UTC tap --cov test/*-test.js",
+    "posttest-cov": "npm run posttest",
     "test-cov-html": "TZ=UTC tap --coverage-report=html test/*-test.js"
   },
   "repository": {
@@ -33,6 +35,7 @@
     "@iterables/reduce": "^1.0.1",
     "@iterables/zip": "^1.0.2",
     "bluebird": "^3.4.6",
+    "clone": "^2.1.1",
     "concat-stream": "^1.6.0",
     "joi": "^13.1.0",
     "pg-query-stream": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@iterables/reduce": "^1.0.1",
     "@iterables/zip": "^1.0.2",
     "bluebird": "^3.4.6",
-    "clone": "^2.1.1",
     "concat-stream": "^1.6.0",
     "joi": "^13.1.0",
+    "lodash.clonedeep": "^4.5.0",
     "pg-query-stream": "^1.0.0",
     "quotemeta": "0.0.0"
   },

--- a/test/decorators-test.js
+++ b/test/decorators-test.js
@@ -32,7 +32,7 @@ test('autonow: throws when no column is passed', assert => {
 
 test('autonow: throws when given a column that does not exist', assert => {
   assert.throws(() => {
-    Item.wrappedObjects = autoNow(Item.objects, { column: 'not_here' })
+    Item.wrappedObjects = autoNow(Item.objects, {column: 'not_here'})
   }, {
     message: 'Column "not_here" does not exist and cannot be configured for automatic timestamps'
   })
@@ -41,10 +41,10 @@ test('autonow: throws when given a column that does not exist', assert => {
 })
 
 test('autonow: throws when trying to attach to the same column twice', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
 
   assert.throws(() => {
-    Item.doubleWrappedObjects = autoNow(Item.wrappedObjects, { column: 'created' })
+    Item.doubleWrappedObjects = autoNow(Item.wrappedObjects, {column: 'created'})
   }, {
     message: 'The column "created" is already configured for automatic timestamps'
   })
@@ -53,17 +53,17 @@ test('autonow: throws when trying to attach to the same column twice', assert =>
 })
 
 test('autonow: original dao is not modified', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
+  return Item.objects.create({name: 'test'}).then(item => {
     assert.notOk(item.created, 'created column should not be set')
   })
 })
 
 test('autonow: sets the column on create', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, 'test', 'name column should be set')
     assert.notEqual(item.created, null, 'created column should be set')
@@ -71,7 +71,7 @@ test('autonow: sets the column on create', assert => {
 })
 
 test('autonow: sets the column on create when no data is passed', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
 
   return Item.wrappedObjects.create().then(item => {
     assert.ok(item.id, 'id column should be set')
@@ -81,11 +81,11 @@ test('autonow: sets the column on create when no data is passed', assert => {
 })
 
 test('autonow: does not set the column on create if a value is already passed', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
   const created = new Date()
   created.setYear(created.getFullYear() - 1)
 
-  return Item.wrappedObjects.create({ created }).then(item => {
+  return Item.wrappedObjects.create({created}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, null, 'name column should be null')
     assert.same(item.created, created, 'created column should match the given value')
@@ -93,7 +93,7 @@ test('autonow: does not set the column on create if a value is already passed', 
 })
 
 test('autonow: sets the column on create for bulk inserts', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
 
   return Item.wrappedObjects.create([{name: 'one'}, {name: 'two'}]).then(items => {
     assert.equals(items.length, 2, 'should have created two items')
@@ -109,7 +109,7 @@ test('autonow: sets the column on create for bulk inserts', assert => {
 })
 
 test('autonow: sets the column on create for bulk inserts with falsy members', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created'})
 
   return Item.wrappedObjects.create([{name: 'one'}, null]).then(items => {
     assert.equals(items.length, 2, 'should have created two items')
@@ -125,15 +125,15 @@ test('autonow: sets the column on create for bulk inserts with falsy members', a
 })
 
 test('autonow: sets the column on update', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'updated' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'updated'})
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, 'test', 'name column should be set')
     assert.notEqual(item.updated, null, 'updated column should be set')
-    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated' }).then(updated => {
+    return Item.wrappedObjects.filter({id: item.id}).update({name: 'updated'}).then(updated => {
       assert.equals(updated, 1, 'should have updated one row')
-      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+      return Item.wrappedObjects.get({id: item.id}).then(newItem => {
         assert.equals(item.id, newItem.id, 'updated the right item')
         assert.equals(newItem.name, 'updated', 'name column should be updated')
         assert.ok(newItem.updated > item.updated, 'updated column should be updated')
@@ -143,15 +143,15 @@ test('autonow: sets the column on update', assert => {
 })
 
 test('autonow: sets the column on update when given no data', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'updated' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'updated'})
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, 'test', 'name column should be set')
     assert.notEqual(item.updated, null, 'updated column should be set')
-    return Item.wrappedObjects.filter({ id: item.id }).update().then(updated => {
+    return Item.wrappedObjects.filter({id: item.id}).update().then(updated => {
       assert.equals(updated, 1, 'should have updated one row')
-      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+      return Item.wrappedObjects.get({id: item.id}).then(newItem => {
         assert.equals(item.id, newItem.id, 'updated the right item')
         assert.equals(newItem.name, item.name, 'name column should be the same')
         assert.ok(newItem.updated > item.updated, 'updated column should be updated')
@@ -161,17 +161,17 @@ test('autonow: sets the column on update when given no data', assert => {
 })
 
 test('autonow: does not set the column on update if a value is passed', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'updated' })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'updated'})
   const updatedTime = new Date()
   updatedTime.setYear(updatedTime.getFullYear() - 1)
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, 'test', 'name column should be set')
     assert.notEqual(item.updated, null, 'updated column should be set')
-    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated', updated: updatedTime }).then(updated => {
+    return Item.wrappedObjects.filter({id: item.id}).update({name: 'updated', updated: updatedTime}).then(updated => {
       assert.equals(updated, 1, 'should have updated one row')
-      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+      return Item.wrappedObjects.get({id: item.id}).then(newItem => {
         assert.equals(item.id, newItem.id, 'updated the right item')
         assert.equals(newItem.name, 'updated', 'name column should be updated')
         assert.same(newItem.updated, updatedTime, 'updated column should match the given value')
@@ -181,15 +181,15 @@ test('autonow: does not set the column on update if a value is passed', assert =
 })
 
 test('autonow: when createOnly is set only sets the timestamp on create', assert => {
-  Item.wrappedObjects = autoNow(Item.objects, { column: 'created', createOnly: true })
+  Item.wrappedObjects = autoNow(Item.objects, {column: 'created', createOnly: true})
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, 'test', 'name column should be set')
     assert.notEqual(item.created, null, 'created column should be set')
-    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated' }).then(updated => {
+    return Item.wrappedObjects.filter({id: item.id}).update({name: 'updated'}).then(updated => {
       assert.equals(updated, 1, 'should have updated one row')
-      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+      return Item.wrappedObjects.get({id: item.id}).then(newItem => {
         assert.equals(item.id, newItem.id, 'updated the right item')
         assert.equals(newItem.name, 'updated', 'name column should be updated')
         assert.same(newItem.created, item.created, 'created column should remain the same')
@@ -199,16 +199,16 @@ test('autonow: when createOnly is set only sets the timestamp on create', assert
 })
 
 test('autonow: can add two columns with different settings', assert => {
-  Item.wrappedObjects = autoNow(autoNow(Item.objects, { column: 'created', createOnly: true }), { column: 'updated' })
+  Item.wrappedObjects = autoNow(autoNow(Item.objects, {column: 'created', createOnly: true}), {column: 'updated'})
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.ok(item.id, 'id column should be set')
     assert.equals(item.name, 'test', 'name column should be set')
     assert.notEqual(item.created, null, 'created column should be set')
     assert.notEqual(item.updated, null, 'updated column should be set')
-    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated' }).then(updated => {
+    return Item.wrappedObjects.filter({id: item.id}).update({name: 'updated'}).then(updated => {
       assert.equals(updated, 1, 'should have updated one row')
-      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+      return Item.wrappedObjects.get({id: item.id}).then(newItem => {
         assert.equals(item.id, newItem.id, 'updated the right item')
         assert.equals(newItem.name, 'updated', 'name column should be updated')
         assert.same(newItem.created, item.created, 'created column should remain the same')
@@ -240,7 +240,7 @@ test('softdelete: throws when no column is passed', assert => {
 
 test('softdelete: throws when given a column that does not exist', assert => {
   assert.throws(() => {
-    Item.wrappedObjects = softDelete(Item.objects, { column: 'not_here' })
+    Item.wrappedObjects = softDelete(Item.objects, {column: 'not_here'})
   }, {
     message: 'Column "not_here" does not exist and cannot be configured for soft deletions'
   })
@@ -249,20 +249,20 @@ test('softdelete: throws when given a column that does not exist', assert => {
 })
 
 test('softdelete: does not throw when trying to attach to the same column twice', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
   assert.doesNotThrow(() => {
-    Item.doubleWrappedObjects = softDelete(Item.wrappedObjects, { column: 'deleted' })
+    Item.doubleWrappedObjects = softDelete(Item.wrappedObjects, {column: 'deleted'})
   })
 
   assert.end()
 })
 
 test('softdelete: throws when trying to attach to a second column', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
   assert.throws(() => {
-    Item.doubleWrappedObjects = softDelete(Item.wrappedObjects, { column: 'updated' })
+    Item.doubleWrappedObjects = softDelete(Item.wrappedObjects, {column: 'updated'})
   }, {
     message: 'The column "deleted" is already configured for soft deletions'
   })
@@ -271,37 +271,37 @@ test('softdelete: throws when trying to attach to a second column', assert => {
 })
 
 test('softdelete: original dao is not modified', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
-    return Item.objects.delete({ name: 'test' }).then(deleted => {
+  return Item.objects.create({name: 'test'}).then(item => {
+    return Item.objects.delete({name: 'test'}).then(deleted => {
       assert.equals(deleted, 1, 'should have deleted one row')
-      assert.rejects(Item.objects.get({ name: 'test' }), Item.objects.NotFound)
+      assert.rejects(Item.objects.get({name: 'test'}), Item.objects.NotFound)
     })
   })
 })
 
 test('softdelete: sets a value to deleted column when trying to delete', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
-    return Item.wrappedObjects.delete({ name: 'test' })
+  return Item.objects.create({name: 'test'}).then(item => {
+    return Item.wrappedObjects.delete({name: 'test'})
   }).then(deleted => {
     assert.equals(deleted, 1, 'should have soft deleted one row')
-    return Item.objects.get({ name: 'test' })
+    return Item.objects.get({name: 'test'})
   }).then(item => {
     assert.notEqual(item.deleted, null, 'deleted column should be set')
   })
 })
 
 test('softdelete: all() filters soft deleted objects', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
-    return Item.wrappedObjects.delete({ name: 'test' })
+  return Item.objects.create({name: 'test'}).then(item => {
+    return Item.wrappedObjects.delete({name: 'test'})
   }).then(deleted => {
     assert.equals(deleted, 1, 'should have soft deleted one row')
-    return Item.objects.get({ name: 'test' })
+    return Item.objects.get({name: 'test'})
   }).then(item => {
     assert.notEqual(item.deleted, null, 'deleted column should be set')
     return Item.wrappedObjects.all()
@@ -311,51 +311,51 @@ test('softdelete: all() filters soft deleted objects', assert => {
 })
 
 test('softdelete: filter() extends queries to filter soft deleted objects', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
-    return Item.wrappedObjects.delete({ name: 'test' })
+  return Item.objects.create({name: 'test'}).then(item => {
+    return Item.wrappedObjects.delete({name: 'test'})
   }).then(deleted => {
     assert.equals(deleted, 1, 'should have soft deleted one row')
-    return Item.objects.get({ name: 'test' })
+    return Item.objects.get({name: 'test'})
   }).then(item => {
     assert.notEqual(item.deleted, null, 'deleted column should be set')
-    return Item.wrappedObjects.filter({ name: 'test' })
+    return Item.wrappedObjects.filter({name: 'test'})
   }).then(items => {
     assert.equals(items.length, 0, 'should return no rows')
   })
 })
 
 test('softdelete: get() extends queries to filter soft deleted objects', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
-    return Item.wrappedObjects.delete({ name: 'test' })
+  return Item.objects.create({name: 'test'}).then(item => {
+    return Item.wrappedObjects.delete({name: 'test'})
   }).then(deleted => {
     assert.equals(deleted, 1, 'should have soft deleted one row')
-    return Item.objects.get({ name: 'test' })
+    return Item.objects.get({name: 'test'})
   }).then(item => {
     assert.notEqual(item.deleted, null, 'deleted column should be set')
-    assert.rejects(Item.wrappedObjects.get({ name: 'test' }), Item.objects.NotFound)
+    assert.rejects(Item.wrappedObjects.get({name: 'test'}), Item.objects.NotFound)
   })
 })
 
 test('softdelete: filters deleted joins', assert => {
-  Item.wrappedObjects = softDelete(Item.objects, { column: 'deleted' })
-  ItemDetail.wrappedObjects = softDelete(ItemDetail.objects, { column: 'deleted_at' })
+  Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
+  ItemDetail.wrappedObjects = softDelete(ItemDetail.objects, {column: 'deleted_at'})
 
-  return Item.objects.create({ name: 'test' }).then(item => {
-    return ItemDetail.objects.create({ item, comment: 'some item' }).then(detail => {
-      return ItemPrice.objects.create({ item_detail: detail, price: 10 }).then(() => {
-        return Item.wrappedObjects.delete({ id: item.id }).then(count => {
+  return Item.objects.create({name: 'test'}).then(item => {
+    return ItemDetail.objects.create({item, comment: 'some item'}).then(detail => {
+      return ItemPrice.objects.create({item_detail: detail, price: 10}).then(() => {
+        return Item.wrappedObjects.delete({id: item.id}).then(count => {
           assert.equals(count, 1, 'should have deleted one row')
-          return Item.objects.get({ id: item.id })
+          return Item.objects.get({id: item.id})
         }).then(deleted => {
           assert.notEqual(deleted.deleted, null, 'item should be soft deleted')
-          return ItemDetail.wrappedObjects.filter({ 'item.name': 'test' })
+          return ItemDetail.wrappedObjects.filter({'item.name': 'test'})
         }).then(details => {
           assert.equals(details.length, 0, 'should find no results due to deleted item')
-          return ItemDetail.wrappedObjects.filter({ 'item_prices.price:gt': 5 })
+          return ItemDetail.wrappedObjects.filter({'item_prices.price:gt': 5})
         }).then(details => {
           assert.equals(details.length, 1, 'should find one result')
           assert.equals(details[0].id, detail.id, 'should have found the correct item detail')
@@ -363,7 +363,7 @@ test('softdelete: filters deleted joins', assert => {
       })
     })
   }).then(() => {
-    return Item.wrappedObjects.filter({ 'item_details.item_prices.price:gt': 1 }).raw().then(({sql}) => {
+    return Item.wrappedObjects.filter({'item_details.item_prices.price:gt': 1}).raw().then(({sql}) => {
       assert.match(sql, '"item_details"."deleted_at"', 'uses the correct column name for joins')
       assert.notMatch(sql, '"item_prices"."deleted', 'does not filter item prices since that table has no soft deletes')
     })
@@ -373,21 +373,21 @@ test('softdelete: filters deleted joins', assert => {
 test('timestamps: can use combined decorator', assert => {
   Item.wrappedObjects = timestamps(Item.objects)
 
-  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+  return Item.wrappedObjects.create({name: 'test'}).then(item => {
     assert.notEquals(item.created, null, 'created is set')
     assert.notEquals(item.updated, null, 'updated is set')
     assert.equals(item.deleted, null, 'deleted is not set')
-    return Item.wrappedObjects.filter({ name: 'test' }).update({ name: 'again' }).then(updated => {
+    return Item.wrappedObjects.filter({name: 'test'}).update({name: 'again'}).then(updated => {
       assert.equals(updated, 1, 'should have updated 1 row')
-      return Item.wrappedObjects.get({ name: 'again' })
+      return Item.wrappedObjects.get({name: 'again'})
     }).then(updated => {
       assert.same(item.created, updated.created, 'created is untouched')
       assert.ok(item.updated < updated.updated, 'updated is modified')
       assert.equals(item.deleted, null, 'deleted is not set')
-      return Item.wrappedObjects.delete({ name: 'again' })
+      return Item.wrappedObjects.delete({name: 'again'})
     }).then(count => {
       assert.equals(count, 1, 'deleted one row')
-      return Item.objects.get({ id: item.id })
+      return Item.objects.get({id: item.id})
     }).then(rawItem => {
       assert.notEquals(rawItem.deleted, null, 'deleted is set')
       return Item.wrappedObjects.all()

--- a/test/decorators-test.js
+++ b/test/decorators-test.js
@@ -1,0 +1,207 @@
+'use strict'
+
+const {beforeEach, afterEach, teardown, test} = require('tap')
+
+const {Item} = require('./models')
+const autoNow = require('../decorators/autonow')
+const db = require('./db')
+
+db.setup(beforeEach, afterEach, teardown)
+
+test('autonow: throws when argument is not a dao', assert => {
+  assert.throws(() => {
+    Item.wrappedObjects = autoNow(Item)
+  }, {
+    message: 'Expected instance of DAO'
+  })
+
+  assert.end()
+})
+
+test('autonow: throws when no column is passed', assert => {
+  assert.throws(() => {
+    Item.wrappedObjects = autoNow(Item.objects)
+  }, {
+    message: 'Must specify column name for automatic timestamps'
+  })
+
+  assert.end()
+})
+
+test('autonow: throws when trying to attach to the same column twice', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+
+  assert.throws(() => {
+    Item.doubleWrappedObjects = autoNow(Item.wrappedObjects, { column: 'created' })
+  }, {
+    message: 'The column "created" is already configured for automatic timestamps'
+  })
+
+  assert.end()
+})
+
+test('autonow: original dao is not modified', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+
+  return Item.objects.create({ name: 'test' }).then(item => {
+    assert.notOk(item.created, 'created column should not be set')
+  })
+})
+
+test('autonow: sets the column on create', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+
+  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, 'test', 'name column should be set')
+    assert.notEqual(item.created, null, 'created column should be set')
+  })
+})
+
+test('autonow: sets the column on create when no data is passed', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+
+  return Item.wrappedObjects.create().then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, null, 'name column should be null')
+    assert.notEqual(item.created, null, 'created column should be set')
+  })
+})
+
+test('autonow: does not set the column on create if a value is already passed', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+  const created = new Date()
+  created.setYear(created.getFullYear() - 1)
+
+  return Item.wrappedObjects.create({ created }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, null, 'name column should be null')
+    assert.same(item.created, created, 'created column should match the given value')
+  })
+})
+
+test('autonow: sets the column on create for bulk inserts', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+
+  return Item.wrappedObjects.create([{name: 'one'}, {name: 'two'}]).then(items => {
+    assert.equals(items.length, 2, 'should have created two items')
+    assert.ok(items[0].id, 'id column should be set')
+    assert.equals(items[0].name, 'one', 'name column should be set')
+    assert.equals(typeof items[0].created, 'object', 'created column should be set')
+    assert.ok(items[0].created.toISOString(), 'should be a date object')
+    assert.ok(items[1].id, 'id column should be set')
+    assert.equals(items[1].name, 'two', 'name column should be set')
+    assert.equals(typeof items[1].created, 'object', 'created column should be set')
+    assert.ok(items[1].created.toISOString(), 'should be a date object')
+  })
+})
+
+test('autonow: sets the column on create for bulk inserts with falsy members', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created' })
+
+  return Item.wrappedObjects.create([{name: 'one'}, null]).then(items => {
+    assert.equals(items.length, 2, 'should have created two items')
+    assert.ok(items[0].id, 'id column should be set')
+    assert.equals(items[0].name, 'one', 'name column should be set')
+    assert.equals(typeof items[0].created, 'object', 'created column should be set')
+    assert.ok(items[0].created.toISOString(), 'should be a date object')
+    assert.ok(items[1].id, 'id column should be set')
+    assert.equals(items[1].name, null, 'name column should be null')
+    assert.equals(typeof items[1].created, 'object', 'created column should be set')
+    assert.ok(items[1].created.toISOString(), 'should be a date object')
+  })
+})
+
+test('autonow: sets the column on update', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'updated' })
+
+  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, 'test', 'name column should be set')
+    assert.notEqual(item.updated, null, 'updated column should be set')
+    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated' }).then(updated => {
+      assert.equals(updated, 1, 'should have updated one row')
+      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+        assert.equals(item.id, newItem.id, 'updated the right item')
+        assert.equals(newItem.name, 'updated', 'name column should be updated')
+        assert.ok(newItem.updated > item.updated, 'updated column should be updated')
+      })
+    })
+  })
+})
+
+test('autonow: sets the column on update when given no data', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'updated' })
+
+  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, 'test', 'name column should be set')
+    assert.notEqual(item.updated, null, 'updated column should be set')
+    return Item.wrappedObjects.filter({ id: item.id }).update().then(updated => {
+      assert.equals(updated, 1, 'should have updated one row')
+      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+        assert.equals(item.id, newItem.id, 'updated the right item')
+        assert.equals(newItem.name, item.name, 'name column should be the same')
+        assert.ok(newItem.updated > item.updated, 'updated column should be updated')
+      })
+    })
+  })
+})
+
+test('autonow: does not set the column on update if a value is passed', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'updated' })
+  const updatedTime = new Date()
+  updatedTime.setYear(updatedTime.getFullYear() - 1)
+
+  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, 'test', 'name column should be set')
+    assert.notEqual(item.updated, null, 'updated column should be set')
+    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated', updated: updatedTime }).then(updated => {
+      assert.equals(updated, 1, 'should have updated one row')
+      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+        assert.equals(item.id, newItem.id, 'updated the right item')
+        assert.equals(newItem.name, 'updated', 'name column should be updated')
+        assert.same(newItem.updated, updatedTime, 'updated column should match the given value')
+      })
+    })
+  })
+})
+
+test('autonow: when createOnly is set only sets the timestamp on create', assert => {
+  Item.wrappedObjects = autoNow(Item.objects, { column: 'created', createOnly: true })
+
+  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, 'test', 'name column should be set')
+    assert.notEqual(item.created, null, 'created column should be set')
+    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated' }).then(updated => {
+      assert.equals(updated, 1, 'should have updated one row')
+      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+        assert.equals(item.id, newItem.id, 'updated the right item')
+        assert.equals(newItem.name, 'updated', 'name column should be updated')
+        assert.same(newItem.created, item.created, 'created column should remain the same')
+      })
+    })
+  })
+})
+
+test('autonow: can add two columns with different settings', assert => {
+  Item.wrappedObjects = autoNow(autoNow(Item.objects, { column: 'created', createOnly: true }), { column: 'updated' })
+
+  return Item.wrappedObjects.create({ name: 'test' }).then(item => {
+    assert.ok(item.id, 'id column should be set')
+    assert.equals(item.name, 'test', 'name column should be set')
+    assert.notEqual(item.created, null, 'created column should be set')
+    assert.notEqual(item.updated, null, 'updated column should be set')
+    return Item.wrappedObjects.filter({ id: item.id }).update({ name: 'updated' }).then(updated => {
+      assert.equals(updated, 1, 'should have updated one row')
+      return Item.wrappedObjects.get({ id: item.id }).then(newItem => {
+        assert.equals(item.id, newItem.id, 'updated the right item')
+        assert.equals(newItem.name, 'updated', 'name column should be updated')
+        assert.same(newItem.created, item.created, 'created column should remain the same')
+        assert.ok(newItem.updated > item.updated, 'updated column should be updated')
+      })
+    })
+  })
+})

--- a/test/fixture.sql
+++ b/test/fixture.sql
@@ -103,7 +103,11 @@ CREATE TABLE item_details (
   id serial primary key,
   comment text,
   item_id integer default null references "items" ("id") on delete cascade,
-  created timestamp,
-  updated timestamp,
-  deleted timestamp
-)
+  deleted_at timestamp
+);
+
+CREATE TABLE item_prices (
+  id serial primary key,
+  price integer,
+  item_detail_id integer default null references "item_details" ("id") on delete cascade
+);

--- a/test/fixture.sql
+++ b/test/fixture.sql
@@ -90,3 +90,11 @@ CREATE TABLE farouts (
   ref_id integer default null references "refs" ("id") on delete cascade,
   second_ref_id integer default null references "refs" ("id") on delete cascade
 );
+
+CREATE TABLE items (
+  id serial primary key,
+  name text,
+  created timestamp,
+  updated timestamp,
+  deleted timestamp
+);

--- a/test/fixture.sql
+++ b/test/fixture.sql
@@ -98,3 +98,12 @@ CREATE TABLE items (
   updated timestamp,
   deleted timestamp
 );
+
+CREATE TABLE item_details (
+  id serial primary key,
+  comment text,
+  item_id integer default null references "items" ("id") on delete cascade,
+  created timestamp,
+  updated timestamp,
+  deleted timestamp
+)

--- a/test/models.js
+++ b/test/models.js
@@ -78,10 +78,29 @@ Farout.objects = orm(Farout, {
   second_ref: orm.fk(Ref, {nullable: true})
 })
 
+class Item {
+  constructor (obj) {
+    this.id = obj.id
+    this.name = obj.name
+    this.created = obj.created
+    this.updated = obj.updated
+    this.deleted = obj.deleted
+  }
+}
+
+Item.objects = orm(Item, {
+  id: orm.joi.number(),
+  name: orm.joi.string(),
+  created: orm.joi.date(),
+  updated: orm.joi.date(),
+  deleted: orm.joi.date()
+})
+
 module.exports = {
   Invoice,
   LineItem,
   Node,
   Ref,
-  Farout
+  Farout,
+  Item
 }

--- a/test/models.js
+++ b/test/models.js
@@ -96,11 +96,33 @@ Item.objects = orm(Item, {
   deleted: orm.joi.date()
 })
 
+class ItemDetail {
+  constructor (obj) {
+    this.id = obj.id
+    this.comment = obj.comment
+    this.item_id = obj.item_id
+    this.item = obj.item
+    this.created = obj.created
+    this.updated = obj.updated
+    this.deleted = obj.deleted
+  }
+}
+
+ItemDetail.objects = orm(ItemDetail, {
+  id: orm.joi.number(),
+  comment: orm.joi.string(),
+  item: orm.fk(Item, {nullable: true}),
+  created: orm.joi.date(),
+  updated: orm.joi.date(),
+  deleted: orm.joi.date()
+})
+
 module.exports = {
   Invoice,
   LineItem,
   Node,
   Ref,
   Farout,
-  Item
+  Item,
+  ItemDetail
 }

--- a/test/models.js
+++ b/test/models.js
@@ -102,9 +102,7 @@ class ItemDetail {
     this.comment = obj.comment
     this.item_id = obj.item_id
     this.item = obj.item
-    this.created = obj.created
-    this.updated = obj.updated
-    this.deleted = obj.deleted
+    this.deleted_at = obj.deleted_at
   }
 }
 
@@ -112,9 +110,22 @@ ItemDetail.objects = orm(ItemDetail, {
   id: orm.joi.number(),
   comment: orm.joi.string(),
   item: orm.fk(Item, {nullable: true}),
-  created: orm.joi.date(),
-  updated: orm.joi.date(),
-  deleted: orm.joi.date()
+  deleted_at: orm.joi.date()
+})
+
+class ItemPrice {
+  constructor (obj) {
+    this.id = obj.id
+    this.price = obj.price
+    this.item_detail = obj.item_detail
+    this.item_detail_id = obj.item_detail_id
+  }
+}
+
+ItemPrice.objects = orm(ItemPrice, {
+  id: orm.joi.number(),
+  price: orm.joi.number(),
+  item_detail: orm.fk(ItemDetail, {nullable: true})
 })
 
 module.exports = {
@@ -124,5 +135,6 @@ module.exports = {
   Ref,
   Farout,
   Item,
-  ItemDetail
+  ItemDetail,
+  ItemPrice
 }


### PR DESCRIPTION
Other than some minor changes to allow inheritance (which will have no effect on a non-decorated dao), this contains only new code.

- Implements an `autoNow` decorator for created/updated timestamp management
- Implements a `softDelete` decorator for managing soft deletes via timestamp on a column
- Includes a common usage pattern composed `timestamps` decorator to handle created, updated, and soft deletes all at once