### PR TITLE
if we appear to be running .then() in a different domain, rerun in last known domain

### DIFF
--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -253,7 +253,7 @@ class QuerySet {
   then (onsuccess, onfail) {
     if (this._domain && process.domain !== this._domain) {
       return this._domain.run(() => {
-        this.then(onsuccess, onfail)
+        return this.then(onsuccess, onfail)
       })
     }
 

--- a/lib/queryset.js
+++ b/lib/queryset.js
@@ -24,6 +24,8 @@ const daoSym = Symbol('dao')
 
 class QuerySet {
   constructor (dao, parent) {
+    this._domain = process.domain
+
     this._transformer = null
     this._columns = null
     this._Query = null
@@ -249,6 +251,12 @@ class QuerySet {
   }
 
   then (onsuccess, onfail) {
+    if (this._domain && process.domain !== this._domain) {
+      return this._domain.run(() => {
+        this.then(onsuccess, onfail)
+      })
+    }
+
     return new Promise((resolve, reject) => {
       const src = this.createStream()
       const dst = concat({encoding: 'object'}, items => {


### PR DESCRIPTION
This fixes `await Foo.objects.filter()` in Spife.