### PR TITLE
fix: custom foreign key column names

### DIFF
--- a/docs/ref/dao.md
+++ b/docs/ref/dao.md
@@ -79,6 +79,12 @@ like this:
 orm.fk(Model, {nullable: true})
 ```
 
+If you wish to override the foreign column name (from the default `${schemaKey}_id`), you can pass the `column` option, like this:
+
+```js
+orm.fk(Model, {column: 'model_uuid'})
+```
+
 ##### `orm.joi`
 
 The [joi][def-joi] version used by this installation of ORMnomnom. For use

--- a/lib/ormnomnom.js
+++ b/lib/ormnomnom.js
@@ -55,7 +55,7 @@ DAO.setConnection = function (getConnection) {
 }
 
 DAO.fk = function (model, opts = {}) {
-  return {[fkFieldSym]: {model, nullable: opts.nullable}}
+  return {[fkFieldSym]: {model, nullable: opts.nullable, column: opts.column}}
 }
 
 proto.getQuerySet = function () {


### PR DESCRIPTION
Pass the `column` option down from `orm.fk`. Document the possibility.