### PR TITLE
fix: respect softdelete filters

### DIFF
--- a/decorators/softdelete.js
+++ b/decorators/softdelete.js
@@ -60,8 +60,8 @@ module.exports = function (dao, opts = {}) {
       return super.filter(q)
     }
 
-    delete () {
-      return super.update({[column]: new Date()})
+    delete (query) {
+      return (query ? this.filter(query) : this).update({[column]: new Date()})
     }
   }
 


### PR DESCRIPTION
Naked `QuerySet#delete()` appears to support filters (by accounts of
code and documentation), but doesn't seem to do that when wrapped by the
softdelete decorator. This effectively caused ormnomnom to remove all of
affected tables' rows.

Side-note: there seems to be `ormnomnom@5.2.0` (released on `2018-06-15T21:38:17.435Z`) that currently gets pulled by `@npm/spife`, without the latest fixes. I'm not sure if that's the intended effect, but thought it'd be wise to let y'all know, since there are 2 more recent versions released, with lower semver.