### PR TITLE
bug: Fix softdelete decorator to be compatible with array (OR) queries

### DIFF
--- a/test/decorators-test.js
+++ b/test/decorators-test.js
@@ -310,9 +310,8 @@ test('softdelete: all() filters soft deleted objects', assert => {
   })
 })
 
-test('softdelete: filter() extends queries to filter soft deleted objects', assert => {
+test('softdelete: filter() extends queries to filter soft deleted objects and arrays', assert => {
   Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
-
   return Item.objects.create({name: 'test'}).then(item => {
     return Item.wrappedObjects.delete({name: 'test'})
   }).then(deleted => {
@@ -323,10 +322,16 @@ test('softdelete: filter() extends queries to filter soft deleted objects', asse
     return Item.wrappedObjects.filter({name: 'test'})
   }).then(items => {
     assert.equals(items.length, 0, 'should return no rows')
+    return Item.wrappedObjects.filter([
+      {name: 'test'},
+      {name: 'not a name of any item'}
+    ])
+  }).then(items => {
+    assert.equals(items.length, 0, 'should return no rows with OR query')
   })
 })
 
-test('softdelete: get() extends queries to filter soft deleted objects', assert => {
+test('softdelete: get() extends queries to filter soft deleted objects and arrays', assert => {
   Item.wrappedObjects = softDelete(Item.objects, {column: 'deleted'})
 
   return Item.objects.create({name: 'test'}).then(item => {
@@ -336,7 +341,19 @@ test('softdelete: get() extends queries to filter soft deleted objects', assert 
     return Item.objects.get({name: 'test'})
   }).then(item => {
     assert.notEqual(item.deleted, null, 'deleted column should be set')
-    assert.rejects(Item.wrappedObjects.get({name: 'test'}), Item.objects.NotFound)
+    assert.rejects(
+      Item.wrappedObjects.get({name: 'test'}),
+      Item.objects.NotFound,
+      'get on softdelete should reject'
+    )
+    assert.rejects(
+      Item.wrappedObjects.get([
+        {name: 'test'},
+        {name: 'not a name of any item'}
+      ]),
+      Item.objects.NotFound,
+      'get on softdelete should reject with OR query'
+    )
   })
 })
 
@@ -354,11 +371,19 @@ test('softdelete: filters deleted joins', assert => {
           assert.notEqual(deleted.deleted, null, 'item should be soft deleted')
           return ItemDetail.wrappedObjects.filter({'item.name': 'test'})
         }).then(details => {
-          assert.equals(details.length, 0, 'should find no results due to deleted item')
+          assert.equals(details.length, 0, 'filter should find no results due to deleted item')
+          assert.rejects(
+            ItemDetail.wrappedObjects.get({'item.name': 'test'}),
+            ItemDetail.objects.NotFound,
+            'get should find no results due to deleted item'
+          )
           return ItemDetail.wrappedObjects.filter({'item_prices.price:gt': 5})
         }).then(details => {
           assert.equals(details.length, 1, 'should find one result')
           assert.equals(details[0].id, detail.id, 'should have found the correct item detail')
+          return ItemDetail.wrappedObjects.get({'item_prices.price:gt': 5})
+        }).then(d => {
+          assert.equals(d.id, detail.id, 'get() should find one result')
         })
       })
     })

--- a/test/decorators-test.js
+++ b/test/decorators-test.js
@@ -338,22 +338,26 @@ test('softdelete: get() extends queries to filter soft deleted objects and array
     return Item.wrappedObjects.delete({name: 'test'})
   }).then(deleted => {
     assert.equals(deleted, 1, 'should have soft deleted one row')
+    test('get on softdelete should reject', assert => {
+      assert.plan(1)
+      assert.rejects(
+        Item.wrappedObjects.get({name: 'test'}),
+        Item.objects.NotFound
+      )
+    })
+    test('get on softdelete should reject with OR query', assert => {
+      assert.plan(1)
+      assert.rejects(
+        Item.wrappedObjects.get([
+          {name: 'test'},
+          {name: 'not a name of any item'}
+        ]),
+        Item.objects.NotFound
+      )
+    })
     return Item.objects.get({name: 'test'})
   }).then(item => {
     assert.notEqual(item.deleted, null, 'deleted column should be set')
-    assert.rejects(
-      Item.wrappedObjects.get({name: 'test'}),
-      Item.objects.NotFound,
-      'get on softdelete should reject'
-    )
-    assert.rejects(
-      Item.wrappedObjects.get([
-        {name: 'test'},
-        {name: 'not a name of any item'}
-      ]),
-      Item.objects.NotFound,
-      'get on softdelete should reject with OR query'
-    )
   })
 })
 
@@ -372,11 +376,13 @@ test('softdelete: filters deleted joins', assert => {
           return ItemDetail.wrappedObjects.filter({'item.name': 'test'})
         }).then(details => {
           assert.equals(details.length, 0, 'filter should find no results due to deleted item')
-          assert.rejects(
-            ItemDetail.wrappedObjects.get({'item.name': 'test'}),
-            ItemDetail.objects.NotFound,
-            'get should find no results due to deleted item'
-          )
+          test('get should find no results due to deleted item', assert => {
+            assert.plan(1)
+            assert.rejects(
+              ItemDetail.wrappedObjects.get({'item.name': 'test'}),
+              ItemDetail.objects.NotFound
+            )
+          })
           return ItemDetail.wrappedObjects.filter({'item_prices.price:gt': 5})
         }).then(details => {
           assert.equals(details.length, 1, 'should find one result')


### PR DESCRIPTION
The following query won't work if decorated with `softdelete`:
```
objects.filter([
  { 'title': 'title' },
  { 'name': 'or perhaps a name' }
])
```

This PR should add support for `softDelete`s `filter` and `get` being passed array queries. It also extends the `get` method to support join queries.

Two tests are failing, specifically because of two `assert.rejects` statements. They're on line #349 and #375 of `decorators-test.js` Commenting them out causes all tests to pass. Strangely, adding `{skip: true}` to the `extras` object parameter doesn't actually seem to prevent the error.

As a random extra note: it doesn't seem like `assert.rejects` is actually checking that error objects match. For example, changing any of the `Item.objects.NotFound` to `Item.clearlyanundefinederrorproperty` will continue to pass all tests :/ 
EDIT: I discovered that the tap `rejects` assert only checks that the Errors match if the param passed to `assert` is in fact an Error type. Passing in an undefined value messes with the optional parameter handling and doesn't allow it to properly verify Error types.