### PR TITLE
fix: honeycomb-beeline bug workaround

### DIFF
--- a/lib/sql/query.js
+++ b/lib/sql/query.js
@@ -50,7 +50,7 @@ class RowStreamQuery extends Query {
   [TO_STREAM] (db, values, sql, annotations) {
     const query = new QueryStream(sql, values)
     query.annotations = annotations
-    return db.query(query)
+    return db.query(query, () => null)
   }
 }
 


### PR DESCRIPTION
Honeycomb monkeypatches `pg.Client.prototype.query` and wraps the last argument
in a function. This breaks the pg-query-stream integration. An open issue is
linked at the end of this message.

In the meantime, we can pass a dummy argument to `query()`, which will be
wrapped instead.

Issue: https://github.com/honeycombio/beeline-nodejs/issues/173