### PR TITLE
Allow encrypted column password to be supplied by fn

### DIFF
--- a/columns/encrypted.js
+++ b/columns/encrypted.js
@@ -8,16 +8,21 @@ module.exports = encrypted
 
 function encrypted (schema, { password, iron = Iron.defaults }) {
   iron = { ...Iron.defaults, ...(iron || Iron.defaults) }
+  const getPassword = (
+    typeof password === 'function'
+    ? password
+    : () => password
+  )
 
   return orm.col(schema, {
     encode (appData) {
-      return Iron.seal(appData, password, iron)
+      return Iron.seal(appData, getPassword(), iron)
     },
     decode (dbData) {
-      return Iron.unseal(dbData, password, iron)
+      return Iron.unseal(dbData, getPassword(), iron)
     },
     encodeQuery (appData) {
-      return Iron.seal(appData, password, iron)
+      return Iron.seal(appData, getPassword(), iron)
     }
   })
 }

--- a/test/models.js
+++ b/test/models.js
@@ -191,7 +191,7 @@ EncryptedColumnTest.objects = orm(EncryptedColumnTest, {
       }
     }
   }, {
-    password: 'keyboardcat'.repeat(4)
+    password () { return 'keyboardcat'.repeat(4) }
   })
 })
 


### PR DESCRIPTION
This helps with late-bound secrets not present in process.env on startup, such
as those fetched from AWS Secrets Manager.